### PR TITLE
Quote path variables that may contain spaces.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(PROBE_DEVICE_NAME "sysdig")
 
 set(CMD_MAKE make)
 
-set(SYSDIG_DIR ${PROJECT_SOURCE_DIR}/../sysdig)
+set(SYSDIG_DIR "${PROJECT_SOURCE_DIR}/../sysdig")
 
 include(ExternalProject)
 
@@ -151,7 +151,7 @@ ExternalProject_Add(lpeg
                     DEPENDS luajit
 		    URL "http://s3.amazonaws.com/download.draios.com/dependencies/lpeg-1.0.0.tar.gz"
                     URL_MD5 "0aec64ccd13996202ad0c099e2877ece"
-                    BUILD_COMMAND LUA_INCLUDE=${LUAJIT_INCLUDE} ${PROJECT_SOURCE_DIR}/scripts/build-lpeg.sh
+                    BUILD_COMMAND LUA_INCLUDE=${LUAJIT_INCLUDE} "${PROJECT_SOURCE_DIR}/scripts/build-lpeg.sh"
                     BUILD_IN_SOURCE 1
 		    CONFIGURE_COMMAND ""
                     INSTALL_COMMAND "")
@@ -180,9 +180,9 @@ ExternalProject_Add(lyaml
 install(FILES falco.yaml
 	DESTINATION "${DIR_ETC}")
 
-add_subdirectory(${SYSDIG_DIR}/driver ${PROJECT_BINARY_DIR}/driver)
-add_subdirectory(${SYSDIG_DIR}/userspace/libscap ${PROJECT_BINARY_DIR}/userspace/libscap)
-add_subdirectory(${SYSDIG_DIR}/userspace/libsinsp ${PROJECT_BINARY_DIR}/userspace/libsinsp)
+add_subdirectory("${SYSDIG_DIR}/driver" "${PROJECT_BINARY_DIR}/driver")
+add_subdirectory("${SYSDIG_DIR}/userspace/libscap" "${PROJECT_BINARY_DIR}/userspace/libscap")
+add_subdirectory("${SYSDIG_DIR}/userspace/libsinsp" "${PROJECT_BINARY_DIR}/userspace/libsinsp")
 
 add_subdirectory(rules)
 add_subdirectory(scripts)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
-file(COPY ${PROJECT_SOURCE_DIR}/scripts/debian/falco
-	DESTINATION ${PROJECT_BINARY_DIR}/scripts/debian)
+file(COPY "${PROJECT_SOURCE_DIR}/scripts/debian/falco"
+	DESTINATION "${PROJECT_BINARY_DIR}/scripts/debian")
 
-file(COPY ${PROJECT_SOURCE_DIR}/scripts/rpm/falco
-	DESTINATION ${PROJECT_BINARY_DIR}/scripts/rpm)
+file(COPY "${PROJECT_SOURCE_DIR}/scripts/rpm/falco"
+	DESTINATION "${PROJECT_BINARY_DIR}/scripts/rpm")

--- a/userspace/falco/CMakeLists.txt
+++ b/userspace/falco/CMakeLists.txt
@@ -1,12 +1,12 @@
-include_directories(${PROJECT_SOURCE_DIR}/../sysdig/userspace/libsinsp/third-party/jsoncpp)
+include_directories("${PROJECT_SOURCE_DIR}/../sysdig/userspace/libsinsp/third-party/jsoncpp")
 include_directories("${LUAJIT_INCLUDE}")
 
-include_directories(${PROJECT_SOURCE_DIR}/../sysdig/userspace/libscap)
-include_directories(${PROJECT_SOURCE_DIR}/../sysdig/userspace/libsinsp)
+include_directories("${PROJECT_SOURCE_DIR}/../sysdig/userspace/libscap")
+include_directories("${PROJECT_SOURCE_DIR}/../sysdig/userspace/libsinsp")
 include_directories("${PROJECT_BINARY_DIR}/userspace/falco")
 include_directories("${CURL_INCLUDE_DIR}")
 include_directories("${YAMLCPP_INCLUDE_DIR}")
-include_directories(${DRAIOS_DEPENDENCIES_DIR}/yaml-${DRAIOS_YAML_VERSION}/target/include)
+include_directories("${DRAIOS_DEPENDENCIES_DIR}/yaml-${DRAIOS_YAML_VERSION}/target/include")
 
 add_executable(falco configuration.cpp formats.cpp fields.cpp rules.cpp logger.cpp falco.cpp)
 


### PR DESCRIPTION
Make sure that references to variables that may be paths (which in turn
may contain spaces) are quoted, so cmake won't break on the spaces.

This fixes https://github.com/draios/falco/issues/79.

@henridf 