### PR TITLE
Add ability to write output to a program

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -23,3 +23,6 @@ file_output:
 stdout_output:
   enabled: true
 
+program_output:
+  enabled: false
+  program: mail -s "Falco Notification" someone@example.com

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -54,6 +54,20 @@ void falco_configuration::init(string conf_filename, std::list<std::string> &cmd
 		m_outputs.push_back(syslog_output);
 	}
 
+	output_config program_output;
+	program_output.name = "program";
+	if (m_config->get_scalar<bool>("program_output", "enabled", false))
+	{
+		string program;
+		program = m_config->get_scalar<string>("program_output", "program", "");
+		if (program == string(""))
+		{
+			throw sinsp_exception("Error reading config file (" + m_config_file + "): program output enabled but no program in configuration block");
+		}
+		program_output.options["program"] = program;
+		m_outputs.push_back(program_output);
+	}
+
 	if (m_outputs.size() == 0)
 	{
 		throw sinsp_exception("Error reading config file (" + m_config_file + "): No outputs configured. Please configure at least one output file output enabled but no filename in configuration block");

--- a/userspace/falco/lua/output.lua
+++ b/userspace/falco/lua/output.lua
@@ -27,7 +27,7 @@ function mod.file_validate(options)
 end
 
 function mod.file(evt, rule, level, format, options)
-   format = "%evt.time: "..levels[level+1].." "..format
+   format = "*%evt.time: "..levels[level+1].." "..format
    formatter = falco.formatter(format)
    msg = falco.format_event(evt, rule, levels[level+1], formatter)
 
@@ -41,6 +41,22 @@ function mod.syslog(evt, rule, level, format)
    formatter = falco.formatter(format)
    msg = falco.format_event(evt, rule, levels[level+1], formatter)
    falco.syslog(level, msg)
+end
+
+function mod.program(evt, rule, level, format, options)
+
+   format = "*%evt.time: "..levels[level+1].." "..format
+   formatter = falco.formatter(format)
+   msg = falco.format_event(evt, rule, levels[level+1], formatter)
+
+   -- XXX Ideally we'd check that the program ran
+   -- successfully. However, the luajit we're using returns true even
+   -- when the shell can't run the program.
+
+   file = io.popen(options.program, "w")
+
+   file:write(msg, "\n")
+   file:close()
 end
 
 function mod.event(event, rule, level, format)


### PR DESCRIPTION
Add a new output type "program" that writes a formatted event to a
configurable program, using io.popen().

Each notification results in one invocation of the program.

This fixes #99.