### PR TITLE
Add ability to run agent for performance tests.

### DIFF
--- a/test/cpu_monitor.sh
+++ b/test/cpu_monitor.sh
@@ -6,4 +6,4 @@ VARIANT=$3
 RESULTS_FILE=$4
 CPU_INTERVAL=$5
 
-top -d $CPU_INTERVAL -b -p $SUBJ_PID | grep -E '(falco|sysdig)' --line-buffered | awk -v benchmark=$BENCHMARK -v variant=$VARIANT '{printf("{\"sample\": %d, \"benchmark\": \"%s\", \"variant\": \"%s\", \"cpu_usage\": %s},\n", NR, benchmark, variant, $9); fflush();}' >> $RESULTS_FILE
+top -d $CPU_INTERVAL -b -p $SUBJ_PID | grep -E '(falco|sysdig|dragent)' --line-buffered | awk -v benchmark=$BENCHMARK -v variant=$VARIANT '{printf("{\"time\": \"%s\", \"sample\": %d, \"benchmark\": \"%s\", \"variant\": \"%s\", \"cpu_usage\": %s},\n", strftime("%Y-%m-%d %H:%M:%S", systime(), 1), NR, benchmark, variant, $9); fflush();}' >> $RESULTS_FILE


### PR DESCRIPTION
When the root directory contains the name 'agent', assume we're running
an agent and provide appropriate configuration and run the agent using
dragent.

You can make autodrop or falco configurable within the agent via
--agent-autodrop and --falco-agent.

Also include some other small changes like timestamping the json points.

@luca3m wanna double check the agent config?