### PR TITLE
Add ability to run on all events.

### DIFF
--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -56,6 +56,7 @@ static void usage()
 	   " -L                            Show the name and description of all rules and exit.\n"
 	   " -l <rule>                     Show the name and description of the rule with name <rule> and exit.\n"
 	   " -v                            Verbose output.\n"
+	   " -A                            Monitor all events, including those with EF_DROP_FALCO flag.\n"
 	   "\n"
     );
 }
@@ -255,6 +256,7 @@ int falco_init(int argc, char **argv)
 	bool describe_all_rules = false;
 	string describe_rule = "";
 	bool verbose = false;
+	bool all_events = false;
 
 	static struct option long_options[] =
 	{
@@ -274,7 +276,7 @@ int falco_init(int argc, char **argv)
 		// Parse the args
 		//
 		while((op = getopt_long(argc, argv,
-                                        "c:ho:e:r:dp:Ll:v",
+                                        "c:ho:e:r:dp:Ll:vA",
                                         long_options, &long_index)) != -1)
 		{
 			switch(op)
@@ -305,6 +307,9 @@ int falco_init(int argc, char **argv)
 				break;
 			case 'v':
 				verbose = true;
+				break;
+			case 'A':
+				all_events = true;
 				break;
 			case 'l':
 				describe_rule = optarg;
@@ -402,8 +407,11 @@ int falco_init(int argc, char **argv)
 		falco_rules::init(ls);
 
 
-		inspector->set_drop_event_flags(EF_DROP_FALCO);
-		rules->load_rules(config.m_rules_filename, verbose);
+		if(!all_events)
+		{
+			inspector->set_drop_event_flags(EF_DROP_FALCO);
+		}
+		rules->load_rules(config.m_rules_filename, verbose, all_events);
 		falco_logger::log(LOG_INFO, "Parsed rules from file " + config.m_rules_filename + "\n");
 
 		if (describe_all_rules)

--- a/userspace/falco/lua/compiler.lua
+++ b/userspace/falco/lua/compiler.lua
@@ -2,10 +2,15 @@ local parser = require("parser")
 local compiler = {}
 
 compiler.verbose = false
+compiler.all_events = false
 
 function compiler.set_verbose(verbose)
    compiler.verbose = verbose
    parser.set_verbose(verbose)
+end
+
+function compiler.set_all_events(all_events)
+   compiler.all_events = all_events
 end
 
 function map(f, arr)
@@ -274,7 +279,9 @@ function compiler.compile_macro(line, list_defs)
 
    -- Traverse the ast looking for events/syscalls in the ignored
    -- syscalls table. If any are found, return an error.
-   check_for_ignored_syscalls_events(ast, 'macro', line)
+   if not compiler.all_events then
+      check_for_ignored_syscalls_events(ast, 'macro', line)
+   end
 
    return ast
 end
@@ -297,7 +304,9 @@ function compiler.compile_filter(name, source, macro_defs, list_defs)
 
    -- Traverse the ast looking for events/syscalls in the ignored
    -- syscalls table. If any are found, return an error.
-   check_for_ignored_syscalls_events(ast, 'rule', source)
+   if not compiler.all_events then
+      check_for_ignored_syscalls_events(ast, 'rule', source)
+   end
 
    if (ast.type == "Rule") then
       -- Line is a filter, so expand macro references

--- a/userspace/falco/lua/rule_loader.lua
+++ b/userspace/falco/lua/rule_loader.lua
@@ -117,9 +117,10 @@ end
 -- to a rule.
 local state = {macros={}, lists={}, filter_ast=nil, rules_by_name={}, n_rules=0, rules_by_idx={}}
 
-function load_rules(filename, rules_mgr, verbose)
+function load_rules(filename, rules_mgr, verbose, all_events)
 
    compiler.set_verbose(verbose)
+   compiler.set_all_events(all_events)
 
    local f = assert(io.open(filename, "r"))
    local s = f:read("*all")

--- a/userspace/falco/rules.cpp
+++ b/userspace/falco/rules.cpp
@@ -88,7 +88,7 @@ void falco_rules::load_compiler(string lua_main_filename)
 	}
 }
 
-void falco_rules::load_rules(string rules_filename, bool verbose)
+void falco_rules::load_rules(string rules_filename, bool verbose, bool all_events)
 {
 	lua_getglobal(m_ls, m_lua_load_rules.c_str());
 	if(lua_isfunction(m_ls, -1))
@@ -161,7 +161,8 @@ void falco_rules::load_rules(string rules_filename, bool verbose)
 		lua_pushstring(m_ls, rules_filename.c_str());
 		lua_pushlightuserdata(m_ls, this);
 		lua_pushboolean(m_ls, (verbose ? 1 : 0));
-		if(lua_pcall(m_ls, 3, 0, 0) != 0)
+		lua_pushboolean(m_ls, (all_events ? 1 : 0));
+		if(lua_pcall(m_ls, 4, 0, 0) != 0)
 		{
 			const char* lerr = lua_tostring(m_ls, -1);
 			string err = "Error loading rules:" + string(lerr);

--- a/userspace/falco/rules.h
+++ b/userspace/falco/rules.h
@@ -10,7 +10,7 @@ class falco_rules
  public:
 	falco_rules(sinsp* inspector, lua_State *ls, string lua_main_filename);
 	~falco_rules();
-	void load_rules(string rules_filename, bool verbose);
+	void load_rules(string rules_filename, bool verbose, bool all_events);
 	void describe_rule(string *rule);
 	sinsp_filter* get_filter();
 


### PR DESCRIPTION
New command line option 'A', related to the boolean all_events instructs
falco to run on all events, and not just those without the EF_DROP_FALCO
flag set.

When all_events is true, the checks for ignored events/syscalls are
skipped when loading rules.

This fixes #102.