### PR TITLE
Fix docker builds.

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
 	curl \
+	gnupg2 \
 	ca-certificates \
 	gcc \
 	gcc-4.9 && rm -rf /var/lib/apt/lists/*

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
 	bash-completion \
 	curl \
 	ca-certificates \
+	gnupg2 \
 	gcc \
 	gcc-4.9 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
gnupg2 is missing on latest debian:unstable.