### PR TITLE
Don't run the spawned program in a shell.

### DIFF
--- a/examples/nodejs-bad-rest-api/server.js
+++ b/examples/nodejs-bad-rest-api/server.js
@@ -14,8 +14,8 @@ router.get('/', function(req, res) {
 });
 
 router.get('/exec/:cmd', function(req, res) {
-    var output = child_process.execSync(req.params.cmd);
-    res.send(output);
+    var ret = child_process.spawnSync(req.params.cmd);
+    res.send(ret.stdout);
 });
 
 app.use('/api', router);


### PR DESCRIPTION
Instead, run it directly. This avoids false positives when running
non-bash commands and false negatives when trying to run a shell.