### PR TITLE
Install gcc-4.9 from Debian Jessie repositories

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -14,13 +14,15 @@ RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 
-RUN apt-get update \
+RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
 	curl \
 	gnupg2 \
 	ca-certificates \
 	gcc \
+	gcc-5 \
 	gcc-4.9 && rm -rf /var/lib/apt/lists/*
 
 # Terribly terrible hacks: since our base Debian image ships with GCC 5.0 which breaks older kernels,

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -14,13 +14,15 @@ RUN cp /etc/skel/.bashrc /root && cp /etc/skel/.profile /root
 
 ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 
-RUN apt-get update \
+RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
 	curl \
 	ca-certificates \
 	gnupg2 \
 	gcc \
+	gcc-5 \
 	gcc-4.9 && rm -rf /var/lib/apt/lists/*
 
 # Terribly terrible hacks: since our base Debian image ships with GCC 5.0 which breaks older kernels,


### PR DESCRIPTION
As luca did for the agent, install gcc 4.9 from the debian jesse
repository, as it has been removed from unstable.

@luca3m @gianlucaborello this should fix the docker hub build failures.