### PR TITLE
Add jq to docker

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -19,6 +19,7 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
  && apt-get install -y --no-install-recommends \
 	bash-completion \
 	curl \
+	jq \
 	gnupg2 \
 	ca-certificates \
 	gcc \

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -19,6 +19,7 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
  && apt-get install -y --no-install-recommends \
 	bash-completion \
 	curl \
+	jq \
 	ca-certificates \
 	gnupg2 \
 	gcc \

--- a/falco.yaml
+++ b/falco.yaml
@@ -23,6 +23,12 @@ file_output:
 stdout_output:
   enabled: true
 
+# Possible additional things you might want to do with program output:
+#   - send to a slack webhook:
+#         program: "jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/XXX"
+#   - logging (alternate method than syslog):
+#         program: logger -t falco-test
+
 program_output:
   enabled: false
   program: mail -s "Falco Notification" someone@example.com


### PR DESCRIPTION
Add jq to our docker images, which makes it easier to post to slack webhooks.