### PR TITLE
Add k8s/mesos/container info to rule outputs.

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -164,6 +164,15 @@
 # System
 - macro: modules
   condition: evt.type in (delete_module, init_module)
+
+# Use this to test whether the event occurred within a container.
+
+# When displaying container information in the output field, use
+# %container.info, without any leading term (file=%fd.name
+# %container.info user=%user.name, and not file=%fd.name
+# container=%container.info user=%user.name). The output will change
+# based on the context and whether or not -pk/-pm/-pc was specified on
+# the command line.
 - macro: container
   condition: container.id != host
 - macro: interactive
@@ -265,7 +274,7 @@
 - rule: Change thread namespace
   desc: an attempt to change a program/thread\'s namespace (commonly done as a part of creating a container) by calling setns.
   condition: evt.type = setns and not proc.name in (docker_binaries, sysdig, dragent, nsenter)
-  output: "Namespace change (setns) by unexpected program (user=%user.name command=%proc.cmdline container=%container.name (id=%container.id))"
+  output: "Namespace change (setns) by unexpected program (user=%user.name command=%proc.cmdline %container.info)"
   priority: WARNING
 
 - rule: Run shell untrusted
@@ -280,7 +289,7 @@
 - rule: File Open by Privileged Container
   desc: Any open by a privileged container. Exceptions are made for known trusted images.
   condition: (open_read or open_write) and container and container.privileged=true and not trusted_containers
-  output: File opened for read/write by non-privileged container (user=%user.name command=%proc.cmdline container=%container.name (id=%container.id) file=%fd.name)
+  output: File opened for read/write by non-privileged container (user=%user.name command=%proc.cmdline %container.info file=%fd.name)
   priority: WARNING
 
 - macro: sensitive_mount
@@ -289,7 +298,7 @@
 - rule: Sensitive Mount by Container
   desc: Any open by a container that has a mount from a sensitive host directory (i.e. /proc). Exceptions are made for known trusted images.
   condition: (open_read or open_write) and container and sensitive_mount and not trusted_containers
-  output: File opened for read/write by container mounting sensitive directory (user=%user.name command=%proc.cmdline container=%container.name (id=%container.id) file=%fd.name)
+  output: File opened for read/write by container mounting sensitive directory (user=%user.name command=%proc.cmdline %container.info file=%fd.name)
   priority: WARNING
 
 # Anything run interactively by root
@@ -306,7 +315,7 @@
 - rule: Run shell in container
   desc: a shell was spawned by a non-shell program in a container. Container entrypoints are excluded.
   condition: spawned_process and container and shell_procs and proc.pname exists and not proc.pname in (shell_binaries, docker_binaries, initdb, pg_ctl, awk, apache2)
-  output: "Shell spawned in a container other than entrypoint (user=%user.name container_id=%container.id container_name=%container.name shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline)"
+  output: "Shell spawned in a container other than entrypoint (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline)"
   priority: WARNING
 
 # sockfamily ip is to exclude certain processes (like 'groups') that communicate on unix-domain sockets

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -56,18 +56,18 @@ static void usage()
 	   "Options:\n"
 	   " -h, --help                    Print this page\n"
 	   " -c                            Configuration file (default " FALCO_SOURCE_CONF_FILE ", " FALCO_INSTALL_CONF_FILE ")\n"
-	   " -o, --option <key>=<val>      Set the value of option <key> to <val>. Overrides values in configuration file.\n"
-	   "                               <key> can be a two-part <key>.<subkey>\n"
+	   " -A                            Monitor all events, including those with EF_DROP_FALCO flag.\n"
 	   " -d, --daemon                  Run as a daemon\n"
-	   " -p, --pidfile <pid_file>      When run as a daemon, write pid to specified file\n"
-           " -e <events_file>              Read the events from <events_file> (in .scap format) instead of tapping into live.\n"
-           " -r <rules_file>               Rules file (defaults to value set in configuration file, or /etc/falco_rules.yaml).\n"
-	   "                               Can be specified multiple times to read from multiple files.\n"
 	   " -D <pattern>                  Disable any rules matching the regex <pattern>. Can be specified multiple times.\n"
+           " -e <events_file>              Read the events from <events_file> (in .scap format) instead of tapping into live.\n"
 	   " -L                            Show the name and description of all rules and exit.\n"
 	   " -l <rule>                     Show the name and description of the rule with name <rule> and exit.\n"
+	   " -o, --option <key>=<val>      Set the value of option <key> to <val>. Overrides values in configuration file.\n"
+	   "                               <key> can be a two-part <key>.<subkey>\n"
+	   " -P, --pidfile <pid_file>      When run as a daemon, write pid to specified file\n"
+           " -r <rules_file>               Rules file (defaults to value set in configuration file, or /etc/falco_rules.yaml).\n"
+	   "                               Can be specified multiple times to read from multiple files.\n"
 	   " -v                            Verbose output.\n"
-	   " -A                            Monitor all events, including those with EF_DROP_FALCO flag.\n"
 	   "\n"
     );
 }
@@ -175,7 +175,7 @@ int falco_init(int argc, char **argv)
 		{"help", no_argument, 0, 'h' },
 		{"daemon", no_argument, 0, 'd' },
 		{"option", required_argument, 0, 'o'},
-		{"pidfile", required_argument, 0, 'p' },
+		{"pidfile", required_argument, 0, 'P' },
 
 		{0, 0, 0, 0}
 	};
@@ -196,7 +196,7 @@ int falco_init(int argc, char **argv)
 		// Parse the args
 		//
 		while((op = getopt_long(argc, argv,
-                                        "c:ho:e:r:D:dp:Ll:vA",
+                                        "hc:AdD:e:k:K:Ll:m:o:P:p:r:v",
                                         long_options, &long_index)) != -1)
 		{
 			switch(op)
@@ -207,36 +207,37 @@ int falco_init(int argc, char **argv)
 			case 'c':
 				conf_filename = optarg;
 				break;
-			case 'o':
-				cmdline_options.push_back(optarg);
+			case 'A':
+				all_events = true;
 				break;
-			case 'e':
-				scap_filename = optarg;
-				break;
-			case 'r':
-				rules_filenames.push_back(optarg);
+			case 'd':
+				daemon = true;
 				break;
 			case 'D':
 				pattern = optarg;
 				disabled_rule_patterns.insert(pattern);
 				break;
-			case 'd':
-				daemon = true;
+			case 'e':
+				scap_filename = optarg;
 				break;
-			case 'p':
-				pidfilename = optarg;
 				break;
 			case 'L':
 				describe_all_rules = true;
 				break;
-			case 'v':
-				verbose = true;
-				break;
-			case 'A':
-				all_events = true;
-				break;
 			case 'l':
 				describe_rule = optarg;
+				break;
+			case 'o':
+				cmdline_options.push_back(optarg);
+				break;
+			case 'P':
+				pidfilename = optarg;
+				break;
+			case 'r':
+				rules_filenames.push_back(optarg);
+				break;
+			case 'v':
+				verbose = true;
 				break;
 			case '?':
 				result = EXIT_FAILURE;

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -44,6 +44,8 @@ public:
 
 	void add_output(output_config oc);
 
+	void set_extra(string &extra, bool replace_container_info);
+
 	//
 	// ev is an event that has matched some rule. Pass the event
 	// to all configured outputs.
@@ -54,4 +56,6 @@ private:
 	std::string m_lua_add_output = "add_output";
 	std::string m_lua_output_event = "output_event";
 	std::string m_lua_main_filename = "output.lua";
+	std::string m_extra;
+	bool m_replace_container_info;
 };


### PR DESCRIPTION
Add support for -pc/-pk/-pm/-k/-m options that do the same thing as the 
sysdig options--change output formats to have container-friendly
information, pulling information when necessary from kubernetes/mesos.

See commits for more details.

This fixes #131.
