### PR TITLE
Rule fixes for dragent.

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -96,7 +96,7 @@
     ]
 
 - list: sysdigcloud_binaries
-  items: [setup-backend, dragent]
+  items: [setup-backend, dragent, sdchecks]
 
 - list: docker_binaries
   items: [docker, dockerd, exe]
@@ -276,8 +276,8 @@
 
 - rule: Change thread namespace
   desc: an attempt to change a program/thread\'s namespace (commonly done as a part of creating a container) by calling setns.
-  condition: evt.type = setns and not proc.name in (docker_binaries, k8s_binaries, sysdig, dragent, nsenter)
-  output: "Namespace change (setns) by unexpected program (user=%user.name command=%proc.cmdline %container.info)"
+  condition: evt.type = setns and not proc.name in (docker_binaries, k8s_binaries, sysdigcloud_binaries, sysdig, nsenter) and not proc.pname in (sysdigcloud_binaries)
+  output: "Namespace change (setns) by unexpected program (user=%user.name command=%proc.cmdline parent=%proc.pname %container.info)"
   priority: WARNING
 
 - rule: Run shell untrusted


### PR DESCRIPTION
Make sure falco doesn't detect the things draios-agent does as
suspicious. It's possible that you might run open source falco alongside
sysdig cloud.

App checks spawned by sysdig cloud binaries might also change namespace,
so also allow children of sysdigcloud binaries to call setns.