### PR TITLE
Added envvar SYSDIG_SKIP_LOAD to Dockerfile to skip kernel module manipulation

### DIFF
--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 #set -e
 
-echo "* Setting up /usr/src links from host"
+# Set the SYSDIG_SKIP_LOAD variable to skip loading the sysdig kernel module
 
-for i in $(ls $SYSDIG_HOST_ROOT/usr/src)
-do 
-	ln -s $SYSDIG_HOST_ROOT/usr/src/$i /usr/src/$i
-done
+if [[ -z "${SYSDIG_SKIP_LOAD}" ]]; then
+    echo "* Setting up /usr/src links from host"
 
-/usr/bin/sysdig-probe-loader
+    for i in $(ls $SYSDIG_HOST_ROOT/usr/src)
+    do
+        ln -s $SYSDIG_HOST_ROOT/usr/src/$i /usr/src/$i
+    done
+
+    /usr/bin/sysdig-probe-loader
+fi
 
 exec "$@"

--- a/docker/stable/docker-entrypoint.sh
+++ b/docker/stable/docker-entrypoint.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 #set -e
 
-echo "* Setting up /usr/src links from host"
+# Set the SYSDIG_SKIP_LOAD variable to skip loading the sysdig kernel module
 
-for i in $(ls $SYSDIG_HOST_ROOT/usr/src)
-do 
-	ln -s $SYSDIG_HOST_ROOT/usr/src/$i /usr/src/$i
-done
+if [[ -z "${SYSDIG_SKIP_LOAD}" ]]; then
+    echo "* Setting up /usr/src links from host"
 
-/usr/bin/sysdig-probe-loader
+    for i in $(ls $SYSDIG_HOST_ROOT/usr/src)
+    do
+        ln -s $SYSDIG_HOST_ROOT/usr/src/$i /usr/src/$i
+    done
+
+    /usr/bin/sysdig-probe-loader
+fi
 
 exec "$@"


### PR DESCRIPTION
This helps when running on a system which has the module loaded, but getting
access to the module file is hard for some reason.  Since I know that the right
version of the module is loaded I just want Falco to connect.

I tested this with this run command:

docker run -e SYSDIG_SKIP_LOAD=1 -it -v /dev:/host/dev -v /proc:/host/proc --privileged falco

And it successfully connected to Sysdig and started printing out warnings for my
system.
