### PR TITLE
Improve error messages when loading rules.

### DIFF
--- a/userspace/engine/lua/compiler.lua
+++ b/userspace/engine/lua/compiler.lua
@@ -290,8 +290,8 @@ function compiler.compile_macro(line, list_defs)
    local ast, error_msg = parser.parse_filter(line)
 
    if (error_msg) then
-      print ("Compilation error when compiling \""..line.."\": ", error_msg)
-      error(error_msg)
+      msg = "Compilation error when compiling \""..line.."\": ".. error_msg
+      error(msg)
    end
 
    -- Traverse the ast looking for events/syscalls in the ignored
@@ -315,8 +315,8 @@ function compiler.compile_filter(name, source, macro_defs, list_defs)
    local ast, error_msg = parser.parse_filter(source)
 
    if (error_msg) then
-      print ("Compilation error when compiling \""..source.."\": ", error_msg)
-      error(error_msg)
+      msg = "Compilation error when compiling \""..source.."\": "..error_msg
+      error(msg)
    end
 
    -- Traverse the ast looking for events/syscalls in the ignored


### PR DESCRIPTION
Related to the changes in https://github.com/draios/agent/pull/267,
improve error messages when trying to load sets of rules with errors:

 - Check that yaml parsing of rules_content actually resulted in
   something.
 - Return an error for rules that have an empty name.
 - Return an error for yaml objects that aren't a rule/macro/list.
 - When compiling, don't print an error message, simply return one,
   including a wrapper "can not compile ..." string.