### PR TITLE
If we're excluding the process sudo we should also ignore it's children

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -346,7 +346,7 @@
 
 - rule: User mgmt binaries
   desc: activity by any programs that can manage users, passwords, or permissions. sudo and su are excluded. Activity in containers is also excluded--some containers create custom users on top of a base linux distribution at startup.
-  condition: spawned_process and proc.name in (user_mgmt_binaries) and not proc.name in (su, sudo) and not container and not proc.pname in (cron_binaries, systemd, run-parts)
+  condition: spawned_process and proc.name in (user_mgmt_binaries) and not proc.name in (su, sudo) and not container and not proc.pname in (cron_binaries, sudo, systemd, run-parts)
   output: "User management binary command run outside of container (user=%user.name command=%proc.cmdline parent=%proc.pname)"
   priority: WARNING
 


### PR DESCRIPTION
Otherwise we see alerts such as ` command=unix_chkpwd user nullok parent=sudo`

I'm do have a slight concern here that I could be opening up a vector for false negatives. I _think_ we should be good and can confirm that running for instance `sudo passwd` will still alert.