### PR TITLE
Cache formatters.

### DIFF
--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -51,7 +51,10 @@ public:
 	void handle_event(sinsp_evt *ev, std::string &level, std::string &priority, std::string &format);
 
 private:
+	bool m_initialized;
+
 	std::string m_lua_add_output = "add_output";
 	std::string m_lua_output_event = "output_event";
+	std::string m_lua_output_cleanup = "output_cleanup";
 	std::string m_lua_main_filename = "output.lua";
 };

--- a/userspace/falco/lua/output.lua
+++ b/userspace/falco/lua/output.lua
@@ -24,6 +24,8 @@ mod.levels = levels
 
 local outputs = {}
 
+local formatters = {}
+
 function mod.stdout(level, msg)
    print (msg)
 end
@@ -75,14 +77,26 @@ end
 function output_event(event, rule, priority, format)
    local level = level_of(priority)
    format = "*%evt.time: "..levels[level+1].." "..format
-   formatter = formats.formatter(format)
+   if formatters[rule] == nil then
+      formatter = formats.formatter(format)
+      formatters[rule] = formatter
+   else
+      formatter = formatters[rule]
+   end
+
    msg = formats.format_event(event, rule, levels[level+1], formatter)
 
    for index,o in ipairs(outputs) do
       o.output(level, msg, o.config)
    end
+end
 
-   formats.free_formatter(formatter)
+function output_cleanup()
+   for rule, formatter in pairs(formatters) do
+      formats.free_formatter(formatter)
+   end
+
+   formatters = {}
 end
 
 function add_output(output_name, config)


### PR DESCRIPTION
Instead of creating a formatter for each event, cache them and create
them only when needed. A new function output_cleanup cleans up the
cached formatters.