### PR TITLE
Add log levels.

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -9,6 +9,12 @@ json_output: false
 log_stderr: true
 log_syslog: true
 
+# Minimum log level to include in logs. Note: these levels are
+# separate from the priority field of rules. This refers only to the
+# log level of falco's internal logging. Can be one of "emergency",
+# "alert", "critical", "error", "warning", "notice", "info", "debug".
+log_level: info
+
 
 # Where security notifications should go.
 # Multiple outputs can be enabled.

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -101,6 +101,10 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 		throw invalid_argument("Error reading config file (" + m_config_file + "): No outputs configured. Please configure at least one output file output enabled but no filename in configuration block");
 	}
 
+	string log_level = m_config->get_scalar<string>("log_level", "info");
+
+	falco_logger::set_level(log_level);
+
 	falco_logger::log_stderr = m_config->get_scalar<bool>("log_stderr", false);
 	falco_logger::log_syslog = m_config->get_scalar<bool>("log_syslog", true);
 }

--- a/userspace/falco/logger.cpp
+++ b/userspace/falco/logger.cpp
@@ -20,17 +20,61 @@ along with falco.  If not, see <http://www.gnu.org/licenses/>.
 #include "logger.h"
 #include "chisel_api.h"
 
+#include "falco_common.h"
+
 const static struct luaL_reg ll_falco [] =
 {
 	{"syslog", &falco_logger::syslog},
 	{NULL,NULL}
 };
 
+int falco_logger::level = LOG_INFO;
 
 void falco_logger::init(lua_State *ls)
 {
 	luaL_openlib(ls, "falco", ll_falco, 0);
 }
+
+void falco_logger::set_level(string &level)
+{
+	if(level == "emergency")
+	{
+		falco_logger::level = LOG_EMERG;
+	}
+	else if(level == "alert")
+	{
+		falco_logger::level = LOG_ALERT;
+	}
+	else if(level == "critical")
+	{
+		falco_logger::level = LOG_CRIT;
+	}
+	else if(level == "error")
+	{
+		falco_logger::level = LOG_ERR;
+	}
+	else if(level == "warning")
+	{
+		falco_logger::level = LOG_WARNING;
+	}
+	else if(level == "notice")
+	{
+		falco_logger::level = LOG_NOTICE;
+	}
+	else if(level == "info")
+	{
+		falco_logger::level = LOG_INFO;
+	}
+	else if(level == "debug")
+	{
+		falco_logger::level = LOG_DEBUG;
+	}
+	else
+	{
+		throw falco_exception("Unknown log level " + level);
+	}
+}
+
 
 int falco_logger::syslog(lua_State *ls) {
 	int priority = luaL_checknumber(ls, 1);
@@ -49,6 +93,12 @@ bool falco_logger::log_stderr = true;
 bool falco_logger::log_syslog = true;
 
 void falco_logger::log(int priority, const string msg) {
+
+	if(priority > falco_logger::level)
+	{
+		return;
+	}
+
 	if (falco_logger::log_syslog) {
 		::syslog(priority, "%s", msg.c_str());
 	}

--- a/userspace/falco/logger.h
+++ b/userspace/falco/logger.h
@@ -32,11 +32,15 @@ class falco_logger
  public:
 	static void init(lua_State *ls);
 
+	// Will throw exception if level is unknown.
+	static void set_level(string &level);
+
 	// value = falco.syslog(level, message)
 	static int syslog(lua_State *ls);
 
 	static void log(int priority, const string msg);
 
+	static int level;
 	static bool log_stderr;
 	static bool log_syslog;
 };


### PR DESCRIPTION
Previously, log messages had levels, but it only influenced the level
argument passed to syslog(). Now, add the ability to control log level
from falco itself.

New falco.yaml argument "log_level" can be one of the strings
corresponding to the well-known syslog levels, which is converted to a
syslog-style level as integer.

In falco_logger::log(), skip messages below the specified level.