### PR TITLE
Use sinsp utils version of get time.

### DIFF
--- a/userspace/engine/token_bucket.cpp
+++ b/userspace/engine/token_bucket.cpp
@@ -19,6 +19,7 @@ along with falco.  If not, see <http://www.gnu.org/licenses/>.
 #include <cstddef>
 #include <sys/time.h>
 
+#include "utils.h"
 #include "token_bucket.h"
 
 token_bucket::token_bucket()
@@ -35,14 +36,14 @@ void token_bucket::init(uint32_t rate, uint32_t max_tokens)
 	m_rate = rate;
 	m_max_tokens = max_tokens;
 	m_tokens = max_tokens;
-	m_last_seen = get_epoch_ns();
+	m_last_seen = sinsp_utils::get_current_time_ns();
 }
 
 bool token_bucket::claim()
 {
 	// Determine the number of tokens gained. Delta between
 	// last_seen and now, divided by the rate.
-	uint64_t now = get_epoch_ns();
+	uint64_t now = sinsp_utils::get_current_time_ns();
 	uint64_t tokens_gained = (now - m_last_seen) / (m_rate * 1000000000);
 	m_last_seen = now;
 
@@ -67,12 +68,4 @@ bool token_bucket::claim()
 	m_tokens--;
 
 	return true;
-}
-
-uint64_t token_bucket::get_epoch_ns()
-{
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-
-    return tv.tv_sec * (uint64_t) 1000000000 + (tv.tv_usec * 1000);
 }

--- a/userspace/engine/token_bucket.h
+++ b/userspace/engine/token_bucket.h
@@ -40,9 +40,6 @@ public:
 	bool claim();
 private:
 
-	// Utility function to get the time in nanoseconds since the epoch.
-	uint64_t get_epoch_ns();
-
 	//
 	// The number of tokens generated per second.
 	//


### PR DESCRIPTION
sinsp_utils::get_current_time_ns() has the same purpose as
get_epoch_ns(), and now that we're including the token bucket in
falco_engine, it's easy to package the dependency. So use that function
instead.

@luca3m this is what we discussed. It also requires some sysdig cleanups. There will be a separate PR for that.