### PR TITLE
Add apt and apt-get as trusted binaries to spawn shells

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -282,7 +282,7 @@
 
 - rule: Run shell untrusted
   desc: an attempt to spawn a shell by a non-shell program. Exceptions are made for trusted binaries.
-  condition: spawned_process and not container and shell_procs and proc.pname exists and not proc.pname in (cron_binaries, shell_binaries, sshd, sudo, docker_binaries, k8s_binaries, su, tmux, screen, emacs, systemd, login, flock, fbash, nginx, monit, supervisord, dragent, aws, initdb, docker-compose, make, configure, awk, falco, fail2ban-server)
+  condition: spawned_process and not container and shell_procs and proc.pname exists and not proc.pname in (cron_binaries, shell_binaries, sshd, sudo, docker_binaries, k8s_binaries, su, tmux, screen, emacs, systemd, login, flock, fbash, nginx, monit, supervisord, dragent, aws, initdb, docker-compose, make, configure, awk, falco, fail2ban-server, apt-get, apt)
   output: "Shell spawned by untrusted binary (user=%user.name shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline)"
   priority: WARNING
 


### PR DESCRIPTION
Periodically both apt and apt-get will spawn shells to update success timestamps and motd.

```
Warning Shell spawned by untrusted binary (user=root shell=sh parent=apt-get cmdline=sh -c touch /var/lib/apt/periodic/update-success-stamp 2>/dev/null || true) container=host (id=host)
Warning Shell spawned by untrusted binary (user=root shell=sh parent=apt-get cmdline=sh -c /usr/lib/update-notifier/update-motd-updates-available 2>/dev/null || true) container=host (id=host)
Warning Shell spawned by untrusted binary (user=root shell=sh parent=apt cmdline=sh -c touch /var/lib/apt/periodic/update-success-stamp 2>/dev/null || true) container=host (id=host)
Warning Shell spawned by untrusted binary (user=root shell=sh parent=apt cmdline=sh -c /usr/lib/update-notifier/update-motd-updates-available 2>/dev/null || true) container=host (id=host)
```

falco-CLA-1.0-signed-off-by: Jonathan Coetzee <jon@thancoetzee.com>