### PR TITLE
Allow overrides

### DIFF
--- a/test/falco_tests.yaml.in
+++ b/test/falco_tests.yaml.in
@@ -95,6 +95,34 @@ trace_files: !mux
       - rules/double_rule.yaml
     trace_file: trace_files/cat_write.scap
 
+  multiple_rules_overriding:
+    detect: False
+    rules_file:
+      - rules/single_rule.yaml
+      - rules/override_rule.yaml
+    trace_file: trace_files/cat_write.scap
+
+  macro_overriding:
+    detect: False
+    rules_file:
+      - rules/single_rule.yaml
+      - rules/override_macro.yaml
+    trace_file: trace_files/cat_write.scap
+
+  list_overriding:
+    detect: False
+    rules_file:
+      - rules/single_rule.yaml
+      - rules/override_list.yaml
+    trace_file: trace_files/cat_write.scap
+
+  nested_list_overriding:
+    detect: False
+    rules_file:
+      - rules/single_rule.yaml
+      - rules/override_nested_list.yaml
+    trace_file: trace_files/cat_write.scap
+
   invalid_rule_output:
     exit_status: 1
     stderr_contains: "Runtime error: Error loading rules:.* Invalid output format 'An open was seen %not_a_real_field': 'invalid formatting token not_a_real_field'. Exiting."

--- a/test/rules/override_list.yaml
+++ b/test/rules/override_list.yaml
@@ -1,0 +1,2 @@
+- list: cat_capable_binaries
+  items: [not-cat]

--- a/test/rules/override_macro.yaml
+++ b/test/rules/override_macro.yaml
@@ -1,0 +1,2 @@
+- macro: is_cat
+  condition: proc.name in (not-cat)

--- a/test/rules/override_nested_list.yaml
+++ b/test/rules/override_nested_list.yaml
@@ -1,0 +1,2 @@
+- list: cat_binaries
+  items: [not-cat]

--- a/test/rules/override_rule.yaml
+++ b/test/rules/override_rule.yaml
@@ -1,0 +1,5 @@
+- rule: open_from_cat
+  desc: A process named cat does an open
+  condition: evt.type=open and proc.name=not-cat
+  output: "An open was seen (command=%proc.cmdline)"
+  priority: WARNING

--- a/test/rules/single_rule.yaml
+++ b/test/rules/single_rule.yaml
@@ -1,5 +1,11 @@
+- list: cat_binaries
+  items: [cat]
+
+- list: cat_capable_binaries
+  items: [cat_binaries]
+
 - macro: is_cat
-  condition: proc.name=cat
+  condition: proc.name in (cat_capable_binaries)
 
 - rule: open_from_cat
   desc: A process named cat does an open

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -19,6 +19,7 @@ along with falco.  If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <string>
+#include <memory>
 
 #include "sinsp.h"
 #include "filter.h"
@@ -84,6 +85,9 @@ public:
 				list<uint32_t> &evttypes,
 				sinsp_filter* filter);
 
+	// Clear all existing filters.
+	void clear_filters();
+
 	//
 	// Set the sampling ratio, which can affect which events are
 	// matched against the set of rules.
@@ -116,7 +120,7 @@ private:
 	inline bool should_drop_evt();
 
 	falco_rules *m_rules;
-        sinsp_evttype_filter m_evttype_filter;
+	std::unique_ptr<sinsp_evttype_filter> m_evttype_filter;
 
 	//
 	// Here's how the sampling ratio and multiplier influence

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #include "falco_engine.h"
 const static struct luaL_reg ll_falco_rules [] =
 {
+	{"clear_filters", &falco_rules::clear_filters},
 	{"add_filter", &falco_rules::add_filter},
 	{"enable_rule", &falco_rules::enable_rule},
 	{NULL,NULL}
@@ -42,6 +43,24 @@ falco_rules::falco_rules(sinsp* inspector, falco_engine *engine, lua_State *ls)
 void falco_rules::init(lua_State *ls)
 {
 	luaL_openlib(ls, "falco_rules", ll_falco_rules, 0);
+}
+
+int falco_rules::clear_filters(lua_State *ls)
+{
+	if (! lua_islightuserdata(ls, -1))
+	{
+		throw falco_exception("Invalid arguments passed to clear_filters()\n");
+	}
+
+	falco_rules *rules = (falco_rules *) lua_topointer(ls, -1);
+	rules->clear_filters();
+
+	return 0;
+}
+
+void falco_rules::clear_filters()
+{
+	m_engine->clear_filters();
 }
 
 int falco_rules::add_filter(lua_State *ls)

--- a/userspace/engine/rules.h
+++ b/userspace/engine/rules.h
@@ -36,10 +36,12 @@ class falco_rules
 	void describe_rule(string *rule);
 
 	static void init(lua_State *ls);
+	static int clear_filters(lua_State *ls);
 	static int add_filter(lua_State *ls);
 	static int enable_rule(lua_State *ls);
 
  private:
+	void clear_filters();
 	void add_filter(string &rule, list<uint32_t> &evttypes);
 	void enable_rule(string &rule, bool enabled);
 


### PR DESCRIPTION
Allow a subsequent yaml file to override a list, macro, or rule specified in a prior yaml file.

This fixes #176.