### PR TITLE
Prefix outputs with * within the engine.

### DIFF
--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -17,6 +17,7 @@ class FalcoTest(Test):
         """
         self.falcodir = self.params.get('falcodir', '/', default=os.path.join(self.basedir, '../build'))
 
+        self.stdout_contains = self.params.get('stdout_contains', '*', default='')
         self.stderr_contains = self.params.get('stderr_contains', '*', default='')
         self.exit_status = self.params.get('exit_status', '*', default=0)
         self.should_detect = self.params.get('detect', '*', default=False)
@@ -203,6 +204,11 @@ class FalcoTest(Test):
             match = re.search(self.stderr_contains, res.stderr)
             if match is None:
                 self.fail("Stderr of falco process did not contain content matching {}".format(self.stderr_contains))
+
+        if self.stdout_contains != '':
+            match = re.search(self.stdout_contains, res.stdout)
+            if match is None:
+                self.fail("Stdout of falco process '{}' did not contain content matching {}".format(res.stdout, self.stdout_contains))
 
         if res.exit_status != self.exit_status:
             self.error("Falco command \"{}\" exited with unexpected return value {} (!= {})".format(

--- a/test/falco_tests.yaml.in
+++ b/test/falco_tests.yaml.in
@@ -154,6 +154,14 @@ trace_files: !mux
       - rules/single_rule_enabled_flag.yaml
     trace_file: trace_files/cat_write.scap
 
+  null_output_field:
+    detect: True
+    detect_level: WARNING
+    rules_file:
+      - rules/null_output_field.yaml
+    trace_file: trace_files/cat_write.scap
+    stdout_contains: "Warning An open was seen .cport=<NA> command=cat /dev/null."
+
   file_output:
     detect: True
     detect_level: WARNING

--- a/test/rules/null_output_field.yaml
+++ b/test/rules/null_output_field.yaml
@@ -1,0 +1,5 @@
+- rule: open_from_cat
+  desc: A process named cat does an open
+  condition: evt.type=open and proc.name=cat
+  output: "An open was seen (cport=%fd.cport command=%proc.cmdline)"
+  priority: WARNING

--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -436,7 +436,10 @@ function on_event(evt_, rule_id)
       rule_output_counts.by_name[rule.rule] = rule_output_counts.by_name[rule.rule] + 1
    end
 
-   return rule.rule, rule.priority, rule.output
+   -- Prefix output with '*' so formatting is permissive
+   output = "*"..rule.output
+
+   return rule.rule, rule.priority, output
 end
 
 function print_stats()

--- a/userspace/falco/lua/output.lua
+++ b/userspace/falco/lua/output.lua
@@ -76,6 +76,13 @@ end
 
 function output_event(event, rule, priority, format)
    local level = level_of(priority)
+
+   -- If format starts with a *, remove it, as we're adding our own
+   -- prefix here.
+   if format:sub(1,1) == "*" then
+      format = format:sub(2)
+   end
+
    format = "*%evt.time: "..levels[level+1].." "..format
    if formatters[rule] == nil then
       formatter = formats.formatter(format)


### PR DESCRIPTION
Prefix output strings with * so they are always permissive in the
engine.

In falco outputs, which adds its own prefix, remove any leading * before
adding the custom prefix.