### PR TITLE
Add exechealthz as a k8s binary.

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -102,7 +102,7 @@
   items: [docker, dockerd, exe]
 
 - list: k8s_binaries
-  items: [hyperkube, skydns, kube2sky]
+  items: [hyperkube, skydns, kube2sky, exechealthz]
 
 - list: http_server_binaries
   items: [nginx, httpd, httpd-foregroun, lighttpd]


### PR DESCRIPTION
For customers who use
https://github.com/kubernetes/contrib/tree/master/exec-healthz to
perform liveness checking, exechealthz will spawn shells in a
container. Add it to the k8s_binaries list.