### PR TITLE
Rule updates related to other security products

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -99,10 +99,13 @@
   items: [setup-backend, dragent, sdchecks]
 
 - list: docker_binaries
-  items: [docker, dockerd, exe]
+  items: [docker, dockerd, exe, docker-compose]
 
 - list: k8s_binaries
   items: [hyperkube, skydns, kube2sky, exechealthz]
+
+- list: lxd_binaries
+  items: [lxd, lxcfs]
 
 - list: http_server_binaries
   items: [nginx, httpd, httpd-foregroun, lighttpd]
@@ -118,8 +121,8 @@
 - list: package_mgmt_binaries
   items: [
     dpkg, dpkg-preconfigu, dnf, rpm, rpmkey, yum, frontend,
-    apt, apt-get, apt-add-reposit, apt-auto-remova, apt-key,
-    preinst
+    apt, apt-get, aptitude, add-apt-reposit, apt-auto-remova, apt-key,
+    preinst, update-alternat, unattended-upgr
     ]
 
 - macro: package_mgmt_procs
@@ -139,11 +142,26 @@
 - list: user_mgmt_binaries
   items: [login_binaries, passwd_binaries, shadowutils_binaries]
 
+- list: dev_creation_binaries
+  items: [blkid]
+
+- list: aide_wrapper_binaries
+  items: [aide.wrapper, update-aide.con]
+
+- list: hids_binaries
+  items: [aide]
+
+- list: nids_binaries
+  items: [bro, broctl]
+
+- list: monitoring_binaries
+  items: [icinga2, nrpe, npcd, check_sar_perf.]
+
 - macro: system_procs
   condition: proc.name in (coreutils_binaries, user_mgmt_binaries)
 
 - list: mail_binaries
-  items: [sendmail, sendmail-msp, postfix, procmail, exim4]
+  items: [sendmail, sendmail-msp, postfix, procmail, exim4, pickup, showq]
 
 - macro: sensitive_files
   condition: fd.name startswith /etc and (fd.name in (/etc/shadow, /etc/sudoers, /etc/pam.conf) or fd.directory in (/etc/sudoers.d, /etc/pam.d))
@@ -209,6 +227,9 @@
 - macro: python_running_denyhosts
   condition: proc.name=python and (proc.cmdline contains /usr/sbin/denyhosts or proc.cmdline contains /usr/local/bin/denyhosts.py)
 
+- macro: parent_bro_running_python
+  condition: proc.pname=python and proc.cmdline contains /usr/share/broctl
+
 # As a part of kernel upgrades, dpkg will spawn a perl script with the
 # name linux-image-N.N. This macro matches that.
 - macro: parent_linux_image_upgrade_script
@@ -231,7 +252,7 @@
                           package_mgmt_binaries, ssl_mgmt_binaries, dhcp_binaries,
                           ldconfig.real, ldconfig, confd, gpg, insserv,
                           apparmor_parser, update-mime, tzdata.config, tzdata.postinst,
-                          systemd-machine, debconf-show)
+                          systemd-machine, debconf-show, rollerd, bind9.postinst)
     and not proc.pname in (sysdigcloud_binaries)
     and not fd.directory in (/etc/cassandra, /etc/ssl/certs/java)
     and not ansible_running_python
@@ -260,13 +281,13 @@
   priority: WARNING
 
 - list: read_sensitive_file_binaries
-  items: [iptables, ps, lsb_release, check-new-relea, dumpe2fs, accounts-daemon, sshd, vsftpd]
+  items: [iptables, ps, lsb_release, check-new-relea, dumpe2fs, accounts-daemon, sshd, vsftpd, systemd]
 
 - rule: Read sensitive file untrusted
   desc: an attempt to read any sensitive file (e.g. files containing user/password/authentication information). Exceptions are made for known trusted programs.
   condition: >
     sensitive_files and open_read
-    and not proc.name in (user_mgmt_binaries, userexec_binaries, package_mgmt_binaries, cron_binaries, read_sensitive_file_binaries, shell_binaries)
+    and not proc.name in (user_mgmt_binaries, userexec_binaries, package_mgmt_binaries, cron_binaries, read_sensitive_file_binaries, shell_binaries, hids_binaries)
     and not cmp_cp_by_passwd
     and not ansible_running_python
     and not proc.cmdline contains /usr/bin/mandb
@@ -276,7 +297,7 @@
 # Only let rpm-related programs write to the rpm database
 - rule: Write below rpm database
   desc: an attempt to write to the rpm database by any non-rpm related program
-  condition: fd.name startswith /var/lib/rpm and open_write and not proc.name in (dnf,rpm,rpmkey,yum)
+  condition: fd.name startswith /var/lib/rpm and open_write and not proc.name in (dnf,rpm,rpmkey,yum) and not ansible_running_python
   output: "Rpm database opened for writing by a non-rpm program (command=%proc.cmdline file=%fd.name)"
   priority: WARNING
 
@@ -316,7 +337,10 @@
 
 - rule: Change thread namespace
   desc: an attempt to change a program/thread\'s namespace (commonly done as a part of creating a container) by calling setns.
-  condition: evt.type = setns and not proc.name in (docker_binaries, k8s_binaries, sysdigcloud_binaries, sysdig, nsenter) and not proc.pname in (sysdigcloud_binaries)
+  condition: >
+    evt.type = setns
+    and not proc.name in (docker_binaries, k8s_binaries, lxd_binaries, sysdigcloud_binaries, sysdig, nsenter)
+    and not proc.pname in (sysdigcloud_binaries)
   output: "Namespace change (setns) by unexpected program (user=%user.name command=%proc.cmdline parent=%proc.pname %container.info)"
   priority: WARNING
 
@@ -328,7 +352,7 @@
     logrotate, ansible, less, adduser, pycompile, py3compile,
     pyclean, py3clean, pip, pip2, ansible-playboo, man-db,
     init, pluto, mkinitramfs, unattended-upgr, watch, sysdig,
-    landscape-sysin, nessusd, PM2
+    landscape-sysin, nessusd, PM2, syslog-summary
     ]
 
 - rule: Run shell untrusted
@@ -337,8 +361,11 @@
     spawned_process and not container
     and shell_procs
     and proc.pname exists
-    and not proc.pname in (cron_binaries, shell_binaries, known_shell_spawn_binaries, docker_binaries, k8s_binaries, package_mgmt_binaries)
+    and not proc.pname in (cron_binaries, shell_binaries, known_shell_spawn_binaries, docker_binaries,
+                           k8s_binaries, package_mgmt_binaries, aide_wrapper_binaries, nids_binaries,
+                           monitoring_binaries)
     and not parent_ansible_running_python
+    and not parent_bro_running_python
     and not parent_linux_image_upgrade_script
   output: "Shell spawned by untrusted binary (user=%user.name shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline pcmdline=%proc.pcmdline)"
   priority: WARNING
@@ -378,7 +405,13 @@
 
 - rule: Run shell in container
   desc: a shell was spawned by a non-shell program in a container. Container entrypoints are excluded.
-  condition: spawned_process and container and shell_procs and proc.pname exists and not proc.pname in (shell_binaries, docker_binaries, k8s_binaries, initdb, pg_ctl, awk, apache2, falco, cron) and not trusted_containers
+  condition: >
+    spawned_process and container
+    and shell_procs
+    and proc.pname exists
+    and not proc.pname in (shell_binaries, docker_binaries, k8s_binaries, lxd_binaries, aide_wrapper_binaries, nids_binaries,
+                           monitoring_binaries, initdb, pg_ctl, awk, apache2, falco, cron)
+    and not trusted_containers
   output: "Shell spawned in a container other than entrypoint (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline)"
   priority: WARNING
 
@@ -401,8 +434,8 @@
 # sshd, mail programs attempt to setuid to root even when running as non-root. Excluding here to avoid meaningless FPs
 - rule: Non sudo setuid
   desc: an attempt to change users by calling setuid. sudo/su are excluded. user "root" is also excluded, as setuid calls typically involve dropping privileges.
-  condition: evt.type=setuid and evt.dir=> and not user.name=root and not proc.name in (userexec_binaries, mail_binaries, sshd, dbus-daemon-lau)
-  output: "Unexpected setuid call by non-sudo, non-root program (user=%user.name command=%proc.cmdline uid=%evt.arg.uid)"
+  condition: evt.type=setuid and evt.dir=> and not user.name=root and not proc.name in (userexec_binaries, mail_binaries, sshd, dbus-daemon-lau, ping, ping6, critical-stack-)
+  output: "Unexpected setuid call by non-sudo, non-root program (user=%user.name parent=%proc.pname command=%proc.cmdline uid=%evt.arg.uid)"
   priority: WARNING
 
 - rule: User mgmt binaries
@@ -417,7 +450,11 @@
 # (we may need to add additional checks against false positives, see: https://bugs.launchpad.net/ubuntu/+source/rkhunter/+bug/86153)
 - rule: Create files below dev
   desc: creating any files below /dev other than known programs that manage devices. Some rootkits hide files in /dev.
-  condition: fd.directory = /dev and (evt.type = creat or (evt.type = open and evt.arg.flags contains O_CREAT)) and proc.name != blkid and not fd.name in (allowed_dev_files)
+  condition: >
+    fd.directory = /dev and
+    (evt.type = creat or (evt.type = open and evt.arg.flags contains O_CREAT))
+    and not proc.name in (dev_creation_binaries)
+    and not fd.name in (allowed_dev_files)
   output: "File created below /dev by untrusted program (user=%user.name command=%proc.cmdline file=%fd.name)"
   priority: WARNING
 


### PR DESCRIPTION
@juju4, here's a PR that merges most of the changes you suggested with the changes I had already made. 

Generally, if you have sysdig trace files you can share for any of
  these cases, it would be very useful. I can add them to the suite of
  regression tests.

Here are some notes on the differences between the two PRs:
  - I addressed linux-image-4.4 somewhat differently, by having a macro parent_linux_image_upgrade_script which looks for linux-image-* and allows it to run shells. I'm guessing the only FP you noticed was linux-image-4.4 spawning shells?
  - I'm assuming critical-stack is short for critical-stack-intel? From what I could see while running it, the only setuid it does is to drop privileges from root. Given that, the current Non sudo setuid rule should not trigger. Am I missing something?
  - From what I could tell by reading the source code, it's not necessary to add cloud-init to a list dev_creation_binaries as the only file it writes to below /dev is /dev/console. Adding /dev/console to the exclusions list should be enough. Is this correct?
  - For the list of host intrusion detection systems, I made a few changes:
     - Of the files in the list, I only saw the program aide accessing sensitive files.
     - I only saw the aide wrapper binaries aide.wrapper and update-aide.con and syslog-summary spawning shells. Notably not logcheck.
     - Based on that, I only kept a list aide_wrapper_binaries containing aide.wrapper and update-aide.con and added that to the shell spawning rules. The only thing in hids_binaries is aide, and was added to Read sensitive file.  I also added syslog-summary to known_shell_spawn_binaries.
     - I renamed hids_procs (and a few other *_procs in other places) to hids_binaries--generally I use the extension _binaries for lists of programs, and _procs for macros that check that a proc.name (or proc.pname) is in the list of binaries. Also, only aide is in this list.
  - For the list of network intrusion detection systems, I also added a bro_running_python to capture python scripts run by broctl that spawn shells.
  - For the list of monitoring procs, I kept icinga2, nrpe, and check_sar_perf.(py), but I didn't keep the more general scripting programs like perl/php, etc. Since perl and php are so generic I'd rather now allow them to spawn shells. If you know of specific contexts in which python/php/etc scripts are being run, we can add exceptions for those. Look at things like ansible_running_python/bro_running_python for examples.
  - I didn't see orchestration_procs/testing_procs being used anywhere so I didn't include it. I did add ansible/ansible-playboo to the list of shell spawners.
  - From looking at the postfix source, I didn't see the postfix program showq changing its uid via setuid. Do you have a repro case for that? If so, I'll add it to the mail_binaries list.
  - The additions to Read sensitive file untrusted (i.e. iptables, ps, ...) were already covered by the list read_sensitive_files_binaries, so I left them in the list. I did add hids_binaries (which only contains aide, as I mentioned before)
  - In Write below rpm database, rather than allow all python programs, I used the macro ansible_running_python.
  - I made several changes to Run shell in container:
     - Do you have an example of containers that run package management commands as they are run. I definitely know of images that use package management commands to install additional software on top of a base image, but I'd think that would be at image creation time, not container run time.
     - I didn't include monitoring_binaries in the set of container shell spawners as I think it's not all that common to deploy nagios or icinga2 in containers. It looks like nagios containers are community-built, and the icinga2 container says its for dev/test/demo use only.
     - Do you have an example of a container that runs init, install-info, ifup, mkinitramfs, cloud-init, or man-db in a container? Like package_mgmt_procs, I would think it would be more at image creation time.

Wanna take a look at the changes and let me know what you think?