### PR TITLE
Use formatter cache

### DIFF
--- a/userspace/engine/formats.cpp
+++ b/userspace/engine/formats.cpp
@@ -81,7 +81,8 @@ int falco_formats::format_event (lua_State *ls)
 	    !lua_isstring(ls, -2) ||
 	    !lua_isstring(ls, -3) ||
 	    !lua_islightuserdata(ls, -4)) {
-		throw falco_exception("Invalid arguments passed to format_event()\n");
+		lua_pushstring(ls, "Invalid arguments passed to format_event()");
+		lua_error(ls);
 	}
 	sinsp_evt* evt = (sinsp_evt*)lua_topointer(ls, 1);
 	const char *rule = (char *) lua_tostring(ls, 2);

--- a/userspace/engine/formats.h
+++ b/userspace/engine/formats.h
@@ -39,8 +39,13 @@ class falco_formats
 	// falco.free_formatter(formatter)
 	static int free_formatter(lua_State *ls);
 
+	// falco.free_formatters()
+	static int free_formatters(lua_State *ls);
+
 	// formatted_string = falco.format_event(evt, formatter)
 	static int format_event(lua_State *ls);
 
 	static sinsp* s_inspector;
+	static sinsp_evt_formatter_cache *s_formatters;
+	static bool s_json_output;
 };

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -49,7 +49,8 @@ int falco_rules::clear_filters(lua_State *ls)
 {
 	if (! lua_islightuserdata(ls, -1))
 	{
-		throw falco_exception("Invalid arguments passed to clear_filters()\n");
+		lua_pushstring(ls, "Invalid arguments passed to clear_filters()");
+		lua_error(ls);
 	}
 
 	falco_rules *rules = (falco_rules *) lua_topointer(ls, -1);
@@ -70,7 +71,8 @@ int falco_rules::add_filter(lua_State *ls)
 	    ! lua_istable(ls, -2) ||
 	    ! lua_istable(ls, -1))
 	{
-		throw falco_exception("Invalid arguments passed to add_filter()\n");
+		lua_pushstring(ls, "Invalid arguments passed to add_filter()");
+		lua_error(ls);
 	}
 
 	falco_rules *rules = (falco_rules *) lua_topointer(ls, -4);
@@ -122,7 +124,8 @@ int falco_rules::enable_rule(lua_State *ls)
 	    ! lua_isstring(ls, -2) ||
 	    ! lua_isnumber(ls, -1))
 	{
-		throw falco_exception("Invalid arguments passed to enable_rule()\n");
+		lua_pushstring(ls, "Invalid arguments passed to enable_rule()");
+		lua_error(ls);
 	}
 
 	falco_rules *rules = (falco_rules *) lua_topointer(ls, -3);

--- a/userspace/falco/lua/output.lua
+++ b/userspace/falco/lua/output.lua
@@ -24,8 +24,6 @@ mod.levels = levels
 
 local outputs = {}
 
-local formatters = {}
-
 function mod.stdout(level, msg)
    print (msg)
 end
@@ -84,14 +82,8 @@ function output_event(event, rule, priority, format)
    end
 
    format = "*%evt.time: "..levels[level+1].." "..format
-   if formatters[rule] == nil then
-      formatter = formats.formatter(format)
-      formatters[rule] = formatter
-   else
-      formatter = formatters[rule]
-   end
 
-   msg = formats.format_event(event, rule, levels[level+1], formatter)
+   msg = formats.format_event(event, rule, levels[level+1], format)
 
    for index,o in ipairs(outputs) do
       o.output(level, msg, o.config)
@@ -99,11 +91,7 @@ function output_event(event, rule, priority, format)
 end
 
 function output_cleanup()
-   for rule, formatter in pairs(formatters) do
-      formats.free_formatter(formatter)
-   end
-
-   formatters = {}
+   formats.free_formatters()
 end
 
 function add_output(output_name, config)


### PR DESCRIPTION
Use the sinsp_evt_formatter_cache added in
https://github.com/draios/sysdig/pull/771 instead of a local cache. This
simplifies the lua side quite a bit, as it only needs to call
format_output(), and clean up everything via free_formatters() in
output_cleanup().

On the C side, use a sinsp_evt_formatter object and use it in
format_event().
