### PR TITLE
Add gitlab binaries

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -110,6 +110,9 @@
 - list: db_server_binaries
   items: [mysqld]
 
+- list: gitlab_binaries
+  items: [gitlab-shell, git]
+
 - macro: server_procs
   condition: proc.name in (http_server_binaries, db_server_binaries, docker_binaries, sshd)
 
@@ -317,7 +320,7 @@
 
 - rule: Run shell in container
   desc: a shell was spawned by a non-shell program in a container. Container entrypoints are excluded.
-  condition: spawned_process and container and shell_procs and proc.pname exists and not proc.pname in (shell_binaries, docker_binaries, k8s_binaries, initdb, pg_ctl, awk, apache2, falco, cron)
+  condition: spawned_process and container and shell_procs and proc.pname exists and not proc.pname in (shell_binaries, docker_binaries, k8s_binaries, gitlab_binaries, initdb, pg_ctl, awk, apache2, falco, cron)
   output: "Shell spawned in a container other than entrypoint (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline)"
   priority: WARNING
 


### PR DESCRIPTION
Add support for gitlab omnibus containers/pod (https://docs.gitlab.com/omnibus/README.html). 

Example events:
```
Shell spawned in a container other than entrypoint (user=<NA> k8s_gitlab.XXX (id=YYYY) shell=sh parent=sshd cmdline=sh -c /opt/gitlab/embedded/service/gitlab-shell/bin/gitlab-shell key-42)

Shell spawned in a container other than entrypoint (user=<NA> k8s_gitlab.XXX (id=YYY) shell=sh parent=git cmdline=sh -c git-upload-pack '/var/opt/gitlab/git-data/repositories/example/demo_service.git' git-upload-pack '/var/opt/gitlab/git-data/repositories/example/demo_service.git')
```

Might make sense to create a bunch of dedicated gitlab rules as my approach is pretty generic.