### PR TITLE
Add support for gitlab omnibus containers/pod

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -113,6 +113,9 @@
 - list: db_server_binaries
   items: [mysqld]
 
+- list: gitlab_binaries
+  items: [gitlab-shell, git]
+
 - macro: server_procs
   condition: proc.name in (http_server_binaries, db_server_binaries, docker_binaries, sshd)
 
@@ -430,7 +433,7 @@
     and shell_procs
     and proc.pname exists
     and not proc.pname in (shell_binaries, docker_binaries, k8s_binaries, lxd_binaries, aide_wrapper_binaries, nids_binaries,
-                           monitoring_binaries, initdb, pg_ctl, awk, apache2, falco, cron)
+                           monitoring_binaries, gitlab_binaries, initdb, pg_ctl, awk, apache2, falco, cron)
     and not trusted_containers
   output: "Shell spawned in a container other than entrypoint (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline)"
   priority: WARNING


### PR DESCRIPTION
Add support for gitlab omnibus containers/pod (https://docs.gitlab.com/omnibus/README.html). 

Example events:
```
Shell spawned in a container other than entrypoint (user=<NA> k8s_gitlab.XXX (id=YYYY) shell=sh parent=sshd cmdline=sh -c /opt/gitlab/embedded/service/gitlab-shell/bin/gitlab-shell key-42)

Shell spawned in a container other than entrypoint (user=<NA> k8s_gitlab.XXX (id=YYY) shell=sh parent=git cmdline=sh -c git-upload-pack '/var/opt/gitlab/git-data/repositories/example/demo_service.git' git-upload-pack '/var/opt/gitlab/git-data/repositories/example/demo_service.git')
```

Might make sense to create a bunch of dedicated gitlab rules as my approach is pretty generic.