### PR TITLE
Add erl_child_setup to shell spawning binaries in a container.

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -433,7 +433,7 @@
     and shell_procs
     and proc.pname exists
     and not proc.pname in (shell_binaries, docker_binaries, k8s_binaries, lxd_binaries, aide_wrapper_binaries, nids_binaries,
-                           monitoring_binaries, gitlab_binaries, initdb, pg_ctl, awk, apache2, falco, cron)
+                           monitoring_binaries, gitlab_binaries, initdb, pg_ctl, awk, apache2, falco, cron, erl_child_setup)
     and not trusted_containers
   output: "Shell spawned in a container other than entrypoint (user=%user.name %container.info shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline)"
   priority: WARNING


### PR DESCRIPTION
Example event:

```
Shell spawned in a container other than entrypoint (user=<NA> k8s_rabbitmq.af7a0ada_rabbitmq-1_data_XXX (id=YYY) shell=sh parent=erl_child_setup cmdline=sh -c exec /bin/sh -s unix:cmd)
```