### PR TITLE
Make sure entrypoint runs for docker pod.

### DIFF
--- a/examples/k8s-using-daemonset/falco-daemonset.yaml
+++ b/examples/k8s-using-daemonset/falco-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
           image: sysdig/falco:latest
           securityContext:
             privileged: true
-          command: [ "/usr/bin/falco", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://kubernetes", "-pk", "-o", "json_output=true", "-o", "program_output.enabled=true", "-o",  "program_output.program=jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/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"]
+          args: [ "/usr/bin/falco", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://kubernetes", "-pk", "-o", "json_output=true", "-o", "program_output.enabled=true", "-o",  "program_output.program=jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/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"]
           volumeMounts:
             - mountPath: /host/var/run/docker.sock
               name: docker-socket


### PR DESCRIPTION
If a daemonset specifies a command, this overrides the entrypoint. In
falco's case, the entrypoint handles the details of loading the kernel
driver, so specifying a command accidently prevents the driver from
being loaded.

This happens to work if you had a previously loaded sysdig_probe driver
lying around.

The fix is to specify args instead. In this case, the driver will be
loaded via the entrypoint.

This fixes https://github.com/draios/falco/issues/225.