### PR TITLE
Allow for an external clock in token bucket.

### DIFF
--- a/userspace/engine/token_bucket.cpp
+++ b/userspace/engine/token_bucket.cpp
@@ -31,7 +31,7 @@ token_bucket::~token_bucket()
 {
 }
 
-void token_bucket::init(uint32_t rate, uint32_t max_tokens)
+void token_bucket::init(double rate, double max_tokens)
 {
 	m_rate = rate;
 	m_max_tokens = max_tokens;
@@ -48,7 +48,7 @@ bool token_bucket::claim(uint64_t now)
 		now = sinsp_utils::get_current_time_ns();
 	}
 
-	uint64_t tokens_gained = (now - m_last_seen) / (m_rate * 1000000000);
+	double tokens_gained = (now - m_last_seen) / (m_rate * 1000000000);
 	m_last_seen = now;
 
 	m_tokens += tokens_gained;

--- a/userspace/engine/token_bucket.cpp
+++ b/userspace/engine/token_bucket.cpp
@@ -39,11 +39,15 @@ void token_bucket::init(uint32_t rate, uint32_t max_tokens)
 	m_last_seen = sinsp_utils::get_current_time_ns();
 }
 
-bool token_bucket::claim()
+bool token_bucket::claim(uint64_t now)
 {
 	// Determine the number of tokens gained. Delta between
 	// last_seen and now, divided by the rate.
-	uint64_t now = sinsp_utils::get_current_time_ns();
+	if(now == 0)
+	{
+		now = sinsp_utils::get_current_time_ns();
+	}
+
 	uint64_t tokens_gained = (now - m_last_seen) / (m_rate * 1000000000);
 	m_last_seen = now;
 

--- a/userspace/engine/token_bucket.h
+++ b/userspace/engine/token_bucket.h
@@ -31,7 +31,7 @@ public:
 	//
 	// Initialize the token bucket and start accumulating tokens
 	//
-	void init(uint32_t rate, uint32_t max_tokens);
+	void init(double rate, double max_tokens);
 
 	//
 	// Returns true if a token can be claimed. Also updates
@@ -43,18 +43,18 @@ private:
 	//
 	// The number of tokens generated per second.
 	//
-	uint64_t m_rate;
+	double m_rate;
 
 	//
 	// The maximum number of tokens that can be banked for future
 	// claim()s.
 	//
-	uint64_t m_max_tokens;
+	double m_max_tokens;
 
 	//
 	// The current number of tokens
 	//
-	uint64_t m_tokens;
+	double m_tokens;
 
 	//
 	// The last time claim() was called (or the object was created).

--- a/userspace/engine/token_bucket.h
+++ b/userspace/engine/token_bucket.h
@@ -37,7 +37,7 @@ public:
 	// Returns true if a token can be claimed. Also updates
 	// internal metrics.
 	//
-	bool claim();
+	bool claim(uint64_t now = 0);
 private:
 
 	//


### PR DESCRIPTION
Allow now to be externally provided to avoid unnecessary gettimeofday()
calls.