### PR TITLE
Add gitlab-mon command

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -114,7 +114,7 @@
   items: [mysqld]
 
 - list: gitlab_binaries
-  items: [gitlab-shell, git]
+  items: [gitlab-shell, gitlab-mon, git]
 
 - macro: server_procs
   condition: proc.name in (http_server_binaries, db_server_binaries, docker_binaries, sshd)


### PR DESCRIPTION
Recent gitlab versions introduce a new command: gitlab-mon

Example alert:

```
Shell spawned in a container other than entrypoint (user=<NA> k8s_gitlab.XXXX_gitlab-YYYYY-zdl1l_default_E7B5CE6A-5F96-4771-A20E-275F2C9C199C (id=275F2C9C199C) shell=sh parent=gitlab-mon cmdline=sh -c pgrep -f "git-upload-pack --stateless-rpc")
```