### PR TITLE
Address some setns FPs.

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -241,6 +241,9 @@
 - macro: parent_linux_image_upgrade_script
   condition: proc.pname startswith linux-image-
 
+- macro: java_running_sdjagent
+  condition: proc.name=java and proc.cmdline contains sdjagent.jar
+
 ###############
 # General Rules
 ###############
@@ -355,7 +358,9 @@
   condition: >
     evt.type = setns
     and not proc.name in (docker_binaries, k8s_binaries, lxd_binaries, sysdigcloud_binaries, sysdig, nsenter)
+    and not proc.name startswith "runc:"
     and not proc.pname in (sysdigcloud_binaries)
+    and not java_running_sdjagent
   output: "Namespace change (setns) by unexpected program (user=%user.name command=%proc.cmdline parent=%proc.pname %container.info)"
   priority: WARNING
   tags: [process]


### PR DESCRIPTION
Allow the sysdig cloud agent to call setns to collect java process
metrics.

We've also seen cases where some of the intermediate processes created
below runc appear to call setns. It appears that this only should happen
if some events (like the execve that spawns the intermediate processes)
are lost, but just to be safe allow processes starting with "runc:" to
call setns.