### PR TITLE
Explicitly spawn program via shell.

### DIFF
--- a/examples/nodejs-bad-rest-api/server.js
+++ b/examples/nodejs-bad-rest-api/server.js
@@ -14,7 +14,7 @@ router.get('/', function(req, res) {
 });
 
 router.get('/exec/:cmd', function(req, res) {
-    var ret = child_process.spawnSync(req.params.cmd);
+    var ret = child_process.spawnSync(req.params.cmd, { shell: true});
     res.send(ret.stdout);
 });
 


### PR DESCRIPTION
So example continues to work.