### PR TITLE
Remove trailing newlines from output

### DIFF
--- a/userspace/engine/lua/compiler.lua
+++ b/userspace/engine/lua/compiler.lua
@@ -20,6 +20,7 @@ local compiler = {}
 
 compiler.verbose = false
 compiler.all_events = false
+compiler.trim = parser.trim
 
 function compiler.set_verbose(verbose)
    compiler.verbose = verbose

--- a/userspace/engine/lua/parser.lua
+++ b/userspace/engine/lua/parser.lua
@@ -127,6 +127,7 @@ function trim(s)
    if (type(s) ~= "string") then return s end
   return (s:gsub("^%s*(.-)%s*$", "%1"))
 end
+parser.trim = trim
 
 local function terminal (tag)
    -- Rather than trim the whitespace in this way, it would be nicer to exclude it from the capture...

--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -243,6 +243,10 @@ function load_rules(rules_content, rules_mgr, verbose, all_events, extra, replac
 	    state.ordered_rule_names[#state.ordered_rule_names+1] = v['rule']
 	 end
 
+	 -- The output field might be a folded-style, which adds a
+	 -- newline to the end. Remove any trailing newlines.
+	 v['output'] = compiler.trim(v['output'])
+
 	 state.rules_by_name[v['rule']] = v
 
       else


### PR DESCRIPTION
If in yaml, the output field is folded-style aka:

output: <
   some multi-line
   output here

The unfolded string will have a trailing newline. Remove it.