### PR TITLE
Add ability to append to rules/macros

### DIFF
--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -599,3 +599,44 @@ trace_files: !mux
     rules_file:
       - rules/list_append_false.yaml
     trace_file: trace_files/cat_write.scap
+
+  macro_append_failure:
+    exit_status: 1
+    stderr_contains: "Macro my_macro has 'append' key but no macro by that name already exists. Exiting"
+    rules_file:
+      - rules/macro_append_failure.yaml
+    trace_file: trace_files/cat_write.scap
+
+  macro_append:
+    detect: True
+    detect_level: WARNING
+    rules_file:
+      - rules/macro_append.yaml
+    trace_file: trace_files/cat_write.scap
+
+  macro_append_false:
+    detect: False
+    rules_file:
+      - rules/macro_append_false.yaml
+    trace_file: trace_files/cat_write.scap
+
+  rule_append_failure:
+    exit_status: 1
+    stderr_contains: "Rule my_rule has 'append' key but no rule by that name already exists. Exiting"
+    rules_file:
+      - rules/rule_append_failure.yaml
+    trace_file: trace_files/cat_write.scap
+
+  rule_append:
+    detect: True
+    detect_level: WARNING
+    rules_file:
+      - rules/rule_append.yaml
+    trace_file: trace_files/cat_write.scap
+
+  rule_append_false:
+    detect: False
+    rules_file:
+      - rules/rule_append_false.yaml
+    trace_file: trace_files/cat_write.scap
+

--- a/test/rules/macro_append.yaml
+++ b/test/rules/macro_append.yaml
@@ -1,0 +1,12 @@
+- macro: my_macro
+  condition: proc.name=not-cat
+
+- macro: my_macro
+  append: true
+  condition: or proc.name=cat
+
+- rule: Open From Cat
+  desc: A process named cat does an open
+  condition: evt.type=open and my_macro
+  output: "An open was seen (command=%proc.cmdline)"
+  priority: WARNING

--- a/test/rules/macro_append_failure.yaml
+++ b/test/rules/macro_append_failure.yaml
@@ -1,0 +1,3 @@
+- macro: my_macro
+  condition: proc.name=not-cat
+  append: true

--- a/test/rules/macro_append_false.yaml
+++ b/test/rules/macro_append_false.yaml
@@ -1,0 +1,12 @@
+- macro: my_macro
+  condition: proc.name=cat
+
+- macro: my_macro
+  append: false
+  condition: proc.name=not-cat
+
+- rule: Open From Cat
+  desc: A process named cat does an open
+  condition: evt.type=open and my_macro
+  output: "An open was seen (command=%proc.cmdline)"
+  priority: WARNING

--- a/test/rules/rule_append.yaml
+++ b/test/rules/rule_append.yaml
@@ -1,0 +1,9 @@
+- rule: my_rule
+  desc: A process named cat does an open
+  condition: evt.type=open and fd.name=not-a-real-file
+  output: "An open of /dev/null was seen (command=%proc.cmdline)"
+  priority: WARNING
+
+- rule: my_rule
+  append: true
+  condition: or fd.name=/dev/null

--- a/test/rules/rule_append_failure.yaml
+++ b/test/rules/rule_append_failure.yaml
@@ -1,0 +1,3 @@
+- rule: my_rule
+  condition: evt.type=open
+  append: true

--- a/test/rules/rule_append_false.yaml
+++ b/test/rules/rule_append_false.yaml
@@ -1,0 +1,9 @@
+- rule: my_rule
+  desc: A process named cat does an open
+  condition: evt.type=open and fd.name=/dev/null
+  output: "An open of /dev/null was seen (command=%proc.cmdline)"
+  priority: WARNING
+
+- rule: my_rule
+  append: true
+  condition: and fd.name=not-a-real-file


### PR DESCRIPTION
Add the ability to append to rules/macros, like we already do with
lists. For rules/macros, if the object has an append: true key, the
condition value is appended to the condition of an existing rule/macro
with the same name.

Like lists, it's an error to specify append: true without there being an
existing rule/macro.

Also add tests that test the same kind of things we did for lists:
 - That append: true really does append
 - That append: false overwrites the rule/macro
 - That it's an error to append with a prior rule/macro existing.