### PR TITLE
Run rules by priority

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -15,6 +15,12 @@ log_syslog: true
 # "alert", "critical", "error", "warning", "notice", "info", "debug".
 log_level: info
 
+# Minimum rule priority level to load and run. All rules having a
+# priority more severe than this level will be loaded/run.  Can be one
+# of "emergency", "alert", "critical", "error", "warning", "notice",
+# "info", "debug".
+priority: debug
+
 # A throttling mechanism implemented as a token bucket limits the
 # rate of falco notifications. This throttling is controlled by the following configuration
 # options:

--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -30,6 +30,7 @@ class FalcoTest(Test):
             self.trace_file = os.path.join(self.basedir, self.trace_file)
 
         self.json_output = self.params.get('json_output', '*', default=False)
+        self.priority = self.params.get('priority', '*', default='debug')
         self.rules_file = self.params.get('rules_file', '*', default=os.path.join(self.basedir, '../rules/falco_rules.yaml'))
 
         if not isinstance(self.rules_file, list):
@@ -347,8 +348,8 @@ class FalcoTest(Test):
             trace_arg = "-e {}".format(self.trace_file)
 
         # Run falco
-        cmd = '{} {} {} -c {} {} -o json_output={} -v'.format(
-            self.falco_binary_path, self.rules_args, self.disabled_args, self.conf_file, trace_arg, self.json_output)
+        cmd = '{} {} {} -c {} {} -o json_output={} -o priority={} -v'.format(
+            self.falco_binary_path, self.rules_args, self.disabled_args, self.conf_file, trace_arg, self.json_output, self.priority)
 
         for tag in self.disable_tags:
             cmd += ' -T {}'.format(tag)

--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -296,7 +296,7 @@ class FalcoTest(Test):
             res = process.run("docker rm falco-test")
 
         elif self.package.endswith(".deb"):
-            cmdline = "dpkg -r falco"
+            cmdline = "dpkg --purge falco"
             self.log.debug("Uninstalling debian package via \"{}\"".format(cmdline))
             res = process.run(cmdline, timeout=120, sudo=True)
 

--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -129,6 +129,21 @@ trace_files: !mux
       - rules/double_rule.yaml
     trace_file: trace_files/cat_write.scap
 
+  multiple_rules_suppress_info:
+    detect: True
+    detect_level:
+      - WARNING
+      - ERROR
+    priority: WARNING
+    detect_counts:
+      - open_from_cat: 8
+      - exec_from_cat: 1
+      - access_from_cat: 0
+    rules_file:
+      - rules/single_rule.yaml
+      - rules/double_rule.yaml
+    trace_file: trace_files/cat_write.scap
+
   multiple_rules_overriding:
     detect: False
     rules_file:

--- a/userspace/engine/falco_common.cpp
+++ b/userspace/engine/falco_common.cpp
@@ -21,6 +21,16 @@ along with falco.  If not, see <http://www.gnu.org/licenses/>.
 #include "config_falco_engine.h"
 #include "falco_common.h"
 
+std::vector<std::string> falco_common::priority_names = {
+	"Emergency",
+	"Alert",
+	"Critical",
+	"Error",
+	"Warning",
+	"Notice",
+	"Informational",
+	"Debug"};
+
 falco_common::falco_common()
 {
 	m_ls = lua_open();

--- a/userspace/engine/falco_common.h
+++ b/userspace/engine/falco_common.h
@@ -74,6 +74,22 @@ public:
 
 	void set_inspector(sinsp *inspector);
 
+        // Priority levels, as a vector of strings
+	static std::vector<std::string> priority_names;
+
+	// Same as numbers/indices into the above vector
+	enum priority_type
+	{
+		PRIORITY_EMERGENCY = 0,
+		PRIORITY_ALERT = 1,
+		PRIORITY_CRITICAL = 2,
+		PRIORITY_ERROR = 3,
+		PRIORITY_WARNING = 4,
+		PRIORITY_NOTICE = 5,
+		PRIORITY_INFORMATIONAL = 6,
+		PRIORITY_DEBUG = 7
+	};
+
 protected:
 	lua_State *m_ls;
 

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -67,10 +67,13 @@ public:
 	// Wrapper that assumes the default ruleset
 	void enable_rule_by_tag(const std::set<std::string> &tags, bool enabled);
 
+	// Only load rules having this priority or more severe.
+	void set_min_priority(falco_common::priority_type priority);
+
 	struct rule_result {
 		sinsp_evt *evt;
 		std::string rule;
-		std::string priority;
+		falco_common::priority_type priority_num;
 		std::string format;
 	};
 
@@ -158,6 +161,7 @@ private:
 	uint16_t m_next_ruleset_id;
 	std::map<string, uint16_t> m_known_rulesets;
 	std::unique_ptr<sinsp_evttype_filter> m_evttype_filter;
+	falco_common::priority_type m_min_priority;
 
 	//
 	// Here's how the sampling ratio and multiplier influence

--- a/userspace/engine/rules.cpp
+++ b/userspace/engine/rules.cpp
@@ -145,7 +145,8 @@ void falco_rules::enable_rule(string &rule, bool enabled)
 
 void falco_rules::load_rules(const string &rules_content,
 			     bool verbose, bool all_events,
-			     string &extra, bool replace_container_info)
+			     string &extra, bool replace_container_info,
+			     falco_common::priority_type min_priority)
 {
 	lua_getglobal(m_ls, m_lua_load_rules.c_str());
 	if(lua_isfunction(m_ls, -1))
@@ -221,7 +222,8 @@ void falco_rules::load_rules(const string &rules_content,
 		lua_pushboolean(m_ls, (all_events ? 1 : 0));
 		lua_pushstring(m_ls, extra.c_str());
 		lua_pushboolean(m_ls, (replace_container_info ? 1 : 0));
-		if(lua_pcall(m_ls, 6, 0, 0) != 0)
+		lua_pushnumber(m_ls, min_priority);
+		if(lua_pcall(m_ls, 7, 0, 0) != 0)
 		{
 			const char* lerr = lua_tostring(m_ls, -1);
 			string err = "Error loading rules:" + string(lerr);

--- a/userspace/engine/rules.h
+++ b/userspace/engine/rules.h
@@ -24,6 +24,8 @@ along with falco.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "lua_parser.h"
 
+#include "falco_common.h"
+
 class falco_engine;
 
 class falco_rules
@@ -32,7 +34,8 @@ class falco_rules
 	falco_rules(sinsp* inspector, falco_engine *engine, lua_State *ls);
 	~falco_rules();
 	void load_rules(const string &rules_content, bool verbose, bool all_events,
-			std::string &extra, bool replace_container_info);
+			std::string &extra, bool replace_container_info,
+			falco_common::priority_type min_priority);
 	void describe_rule(string *rule);
 
 	static void init(lua_State *ls);

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -108,6 +108,19 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 	m_notifications_rate = m_config->get_scalar<uint32_t>("outputs", "rate", 1);
 	m_notifications_max_burst = m_config->get_scalar<uint32_t>("outputs", "max_burst", 1000);
 
+	string priority = m_config->get_scalar<string>("priority", "debug");
+	vector<string>::iterator it;
+
+	auto comp = [priority] (string &s) {
+		return (strcasecmp(s.c_str(), priority.c_str()) == 0);
+	};
+
+	if((it = std::find_if(falco_common::priority_names.begin(), falco_common::priority_names.end(), comp)) == falco_common::priority_names.end())
+	{
+		throw invalid_argument("Unknown priority \"" + priority + "\"--must be one of emergency, alert, critical, error, warning, notice, informational, debug");
+	}
+	m_min_priority = (falco_common::priority_type) (it - falco_common::priority_names.begin());
+
 	falco_logger::log_stderr = m_config->get_scalar<bool>("log_stderr", false);
 	falco_logger::log_syslog = m_config->get_scalar<bool>("log_syslog", true);
 }

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -146,6 +146,8 @@ class falco_configuration
 	std::vector<falco_outputs::output_config> m_outputs;
 	uint32_t m_notifications_rate;
 	uint32_t m_notifications_max_burst;
+
+	falco_common::priority_type m_min_priority;
  private:
 	void init_cmdline_options(std::list<std::string> &cmdline_options);
 

--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -212,7 +212,7 @@ uint64_t do_inspect(falco_engine *engine,
 		unique_ptr<falco_engine::rule_result> res = engine->process_event(ev);
 		if(res)
 		{
-			outputs->handle_event(res->evt, res->rule, res->priority, res->format);
+			outputs->handle_event(res->evt, res->rule, res->priority_num, res->format);
 		}
 
 		num_evts++;
@@ -460,6 +460,8 @@ int falco_init(int argc, char **argv)
 		{
 			config.m_rules_filenames = rules_filenames;
 		}
+
+		engine->set_min_priority(config.m_min_priority);
 
 		for (auto filename : config.m_rules_filenames)
 		{

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -105,7 +105,7 @@ void falco_outputs::add_output(output_config oc)
 
 }
 
-void falco_outputs::handle_event(sinsp_evt *ev, string &rule, string &priority, string &format)
+void falco_outputs::handle_event(sinsp_evt *ev, string &rule, falco_common::priority_type priority, string &format)
 {
 	if(!m_notifications_tb.claim())
 	{
@@ -119,10 +119,11 @@ void falco_outputs::handle_event(sinsp_evt *ev, string &rule, string &priority, 
 	{
 		lua_pushlightuserdata(m_ls, ev);
 		lua_pushstring(m_ls, rule.c_str());
-		lua_pushstring(m_ls, priority.c_str());
+		lua_pushstring(m_ls, falco_common::priority_names[priority].c_str());
+		lua_pushnumber(m_ls, priority);
 		lua_pushstring(m_ls, format.c_str());
 
-		if(lua_pcall(m_ls, 4, 0, 0) != 0)
+		if(lua_pcall(m_ls, 5, 0, 0) != 0)
 		{
 			const char* lerr = lua_tostring(m_ls, -1);
 			string err = "Error invoking function output: " + string(lerr);

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -49,7 +49,7 @@ public:
 	// ev is an event that has matched some rule. Pass the event
 	// to all configured outputs.
 	//
-	void handle_event(sinsp_evt *ev, std::string &rule, std::string &priority, std::string &format);
+	void handle_event(sinsp_evt *ev, std::string &rule, falco_common::priority_type priority, std::string &format);
 
 private:
 	bool m_initialized;


### PR DESCRIPTION
Add ability to only run rules with a minimum priority.

This fixes https://github.com/draios/falco/issues/62.