### PR TITLE
Add ability to make outputs unbuffered

### DIFF
--- a/falco.yaml
+++ b/falco.yaml
@@ -31,6 +31,10 @@ log_level: info
 # "info", "debug".
 priority: debug
 
+# Whether or not output to any of the output channels below is
+# buffered. Defaults to true
+buffered_outputs: true
+
 # A throttling mechanism implemented as a token bucket limits the
 # rate of falco notifications. This throttling is controlled by the following configuration
 # options:

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -22,7 +22,8 @@ along with falco.  If not, see <http://www.gnu.org/licenses/>.
 using namespace std;
 
 falco_configuration::falco_configuration()
-	: m_config(NULL)
+	: m_buffered_outputs(true),
+	  m_config(NULL)
 {
 }
 
@@ -141,6 +142,8 @@ void falco_configuration::init(string conf_filename, list<string> &cmdline_optio
 		throw invalid_argument("Unknown priority \"" + priority + "\"--must be one of emergency, alert, critical, error, warning, notice, informational, debug");
 	}
 	m_min_priority = (falco_common::priority_type) (it - falco_common::priority_names.begin());
+
+	m_buffered_outputs = m_config->get_scalar<bool>("buffered_outputs", true);
 
 	falco_logger::log_stderr = m_config->get_scalar<bool>("log_stderr", false);
 	falco_logger::log_syslog = m_config->get_scalar<bool>("log_syslog", true);

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -172,6 +172,8 @@ class falco_configuration
 	uint32_t m_notifications_max_burst;
 
 	falco_common::priority_type m_min_priority;
+
+	bool m_buffered_outputs;
  private:
 	void init_cmdline_options(std::list<std::string> &cmdline_options);
 

--- a/userspace/falco/falco_outputs.cpp
+++ b/userspace/falco/falco_outputs.cpp
@@ -27,7 +27,8 @@ along with falco.  If not, see <http://www.gnu.org/licenses/>.
 using namespace std;
 
 falco_outputs::falco_outputs()
-	: m_initialized(false)
+	: m_initialized(false),
+	  m_buffered(true)
 {
 
 }
@@ -51,7 +52,7 @@ falco_outputs::~falco_outputs()
 	}
 }
 
-void falco_outputs::init(bool json_output, uint32_t rate, uint32_t max_burst)
+void falco_outputs::init(bool json_output, uint32_t rate, uint32_t max_burst, bool buffered)
 {
 	// The engine must have been given an inspector by now.
 	if(! m_inspector)
@@ -70,12 +71,14 @@ void falco_outputs::init(bool json_output, uint32_t rate, uint32_t max_burst)
 
 	m_notifications_tb.init(rate, max_burst);
 
+	m_buffered = buffered;
+
 	m_initialized = true;
 }
 
 void falco_outputs::add_output(output_config oc)
 {
-	uint8_t nargs = 1;
+	uint8_t nargs = 2;
 	lua_getglobal(m_ls, m_lua_add_output.c_str());
 
 	if(!lua_isfunction(m_ls, -1))
@@ -83,11 +86,12 @@ void falco_outputs::add_output(output_config oc)
 		throw falco_exception("No function " + m_lua_add_output + " found. ");
 	}
 	lua_pushstring(m_ls, oc.name.c_str());
+	lua_pushnumber(m_ls, (m_buffered ? 1 : 0));
 
 	// If we have options, build up a lua table containing them
 	if (oc.options.size())
 	{
-		nargs = 2;
+		nargs = 3;
 		lua_createtable(m_ls, 0, oc.options.size());
 
 		for (auto it = oc.options.cbegin(); it != oc.options.cend(); ++it)

--- a/userspace/falco/falco_outputs.h
+++ b/userspace/falco/falco_outputs.h
@@ -41,7 +41,7 @@ public:
 		std::map<std::string, std::string> options;
 	};
 
-	void init(bool json_output, uint32_t rate, uint32_t max_burst);
+	void init(bool json_output, uint32_t rate, uint32_t max_burst, bool buffered);
 
 	void add_output(output_config oc);
 
@@ -56,6 +56,8 @@ private:
 
 	// Rate limits notifications
 	token_bucket m_notifications_tb;
+
+	bool m_buffered;
 
 	std::string m_lua_add_output = "add_output";
 	std::string m_lua_output_event = "output_event";


### PR DESCRIPTION
A new falco.yaml option buffered_outputs, also controlled by
-U/--unbuffered, sets unbuffered outputs for the output methods. This is
especially useful with keep_alive files/programs where you want the
output right away.

Also add cleanup methods for the output channels that ensure output to
the file/program is flushed and closed.

This fixes the other half of https://github.com/draios/falco/issues/279.