### PR TITLE
Move rules cmakefiles from engine to falco itself

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,8 @@ endif()
 install(FILES falco.yaml
 	DESTINATION "${FALCO_ETC_DIR}")
 
+add_subdirectory(rules)
+
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 	add_subdirectory("${SYSDIG_DIR}/driver" "${PROJECT_BINARY_DIR}/driver")
 endif()

--- a/userspace/engine/CMakeLists.txt
+++ b/userspace/engine/CMakeLists.txt
@@ -27,5 +27,3 @@ install(DIRECTORY lua
 	DESTINATION "${FALCO_SHARE_DIR}"
 	FILES_MATCHING PATTERN *.lua)
 endif()
-
-add_subdirectory("${PROJECT_SOURCE_DIR}/../falco/rules" "${PROJECT_BINARY_DIR}/rules")


### PR DESCRIPTION
The rules CMakeLists.txt, which controls the installation of the falco
rules files, was in the engine CMakeLists.txt, which meant that programs
that included the engine would also include rules files.

This may not always be desired, so move the rules CMakeLists.txt to the
main falco CMakeLists.txt instead.