### PR TITLE
Expose evttypes for ruleset

### DIFF
--- a/userspace/engine/falco_engine.cpp
+++ b/userspace/engine/falco_engine.cpp
@@ -154,6 +154,13 @@ uint16_t falco_engine::find_ruleset_id(const std::string &ruleset)
 	return it->second;
 }
 
+void falco_engine::evttypes_for_ruleset(std::vector<bool> &evttypes, const std::string &ruleset)
+{
+	uint16_t ruleset_id = find_ruleset_id(ruleset);
+
+	return m_evttype_filter->evttypes_for_ruleset(evttypes, ruleset_id);
+}
+
 unique_ptr<falco_engine::rule_result> falco_engine::process_event(sinsp_evt *ev, uint16_t ruleset_id)
 {
 	if(should_drop_evt())

--- a/userspace/engine/falco_engine.h
+++ b/userspace/engine/falco_engine.h
@@ -86,6 +86,12 @@ public:
 	uint16_t find_ruleset_id(const std::string &ruleset);
 
 	//
+	// Given a ruleset, fill in a bitset containing the event
+	// types for which this ruleset can run.
+	//
+	void evttypes_for_ruleset(std::vector<bool> &evttypes, const std::string &ruleset);
+
+	//
 	// Given an event, check it against the set of rules in the
 	// engine and if a matching rule is found, return details on
 	// the rule that matched. If no rule matched, returns NULL.


### PR DESCRIPTION
Add the ability to return the specific event types that are relevant for
a given ruleset. Allows pre-filtering based on ruleset outside the
engine.

This depends on https://github.com/draios/sysdig/pull/958.