### PR TITLE
Add gdb in the development Docker image (sysdig/falco:dev) to help debugging

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -24,7 +24,8 @@ RUN echo "deb http://httpredir.debian.org/debian jessie main" > /etc/apt/sources
 	ca-certificates \
 	gcc \
 	gcc-5 \
-	gcc-4.9 && rm -rf /var/lib/apt/lists/*
+	gcc-4.9 \
+	gdb && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 5.0 which breaks older kernels, revert the
 # default to gcc-4.9. Also, since some customers use some very old distributions whose kernel


### PR DESCRIPTION
`gdb` can be very useful when trying to debug some issues with Falco or Sysdig. Adding it in the base image will allow us to do things like:

```YAML
containers:
  - name: falco
    image: 'sysdig/falco:dev'
    securityContext:
      privileged: true
    args:
      - /usr/bin/gdb
      - '-ex'
      - 'run'
      - '-ex'
      - 'bt'
      - '--args'
      - /usr/bin/falco
      - '-K'
      - /var/run/secrets/kubernetes.io/serviceaccount/token
      - '-k'
      - 'https://kubernetes.default'
      - '-pk'
```

falco-CLA-1.0-contributing-entity: Coveo Solutions Inc.
falco-CLA-1.0-signed-off-by: Jean-Philippe Lachance <jplachance@coveo.com>