### PR TITLE
Update K8S Daemon Set for RBAC & ConfigMap

### DIFF
--- a/examples/k8s-using-daemonset/README.md
+++ b/examples/k8s-using-daemonset/README.md
@@ -40,7 +40,7 @@ program_output:
 You will also need to enable JSON output. Find the `json_output: false` setting in the `falco.yaml` file and change it to read `json_output: true`. Any custom rules for your environment can be added to into the `falco_rules.local.yaml` file and they will be picked up by Falco at start time. You can now create the ConfigMap in Kubernetes. 
 
 ```
-k8s-using-daemonset$ kubectl create configmap falco-config --from-file=k8s-with-rbac/
+k8s-using-daemonset$ kubectl create configmap falco-config --from-file=k8s-with-rbac/falco-config
 configmap "falco-config" created
 k8s-using-daemonset$
 ```

--- a/examples/k8s-using-daemonset/README.md
+++ b/examples/k8s-using-daemonset/README.md
@@ -1,5 +1,92 @@
-# Example K8s Services for Falco
+# Example Kubernetes Daemon Sets for Sysdig Falco
 
-The yaml file in this directory installs the following:
- - Open Source Falco, as a DaemonSet. Falco is configured to communicate with the K8s API server via its service account, and changes its output to be K8s-friendly. It also sends to a slack webhook for the `#demo-falco-alerts` channel on our [public slack](https://sysdig.slack.com/messages/demo-falco-alerts/).
- - The [Falco Event Generator](https://github.com/draios/falco/wiki/Generating-Sample-Events), as a deployment that ensures it runs on exactly 1 node.
+This directory gives you the required YAML files to stand up Sysdig Falco on Kubernetes as a Daemon Set. This will result in a Falco Pod being deployed to each node, and thus the ability to monitor any running containers for abnormal behavior. 
+
+The two options are provided to deploy a Daemon Set:
+- `k8s-with-rbac` - This directory provides a definition to deploy a Daemon Set on Kubernetes with RBAC enabled.
+- `k8s-without-rbac` - This directory provides a definition to deploy a Daemon Set on Kubernetes without RBAC enabled. 
+
+Also provided:
+- `falco-event-generator-deployment.yaml` - A Kubernetes Deployment to generate sample events. This is useful for testing, but note it will generate a large number of events.
+
+## Deploying to Kubernetes with RBAC enabled
+
+Since v1.8 RBAC has been available in Kubernetes, and running with RBAC enabled is considered the best practice. The `k8s-with-rbac` directory provides the YAML to create a Service Account for Falco, as well as the ClusterRoles and bindings to grant the appropriate permissions to the Service Account.
+
+```
+k8s-using-daemonset$ kubectl create -f k8s-with-rbac/falco-account.yaml
+serviceaccount "falco-account" created
+clusterrole "falco-cluster-role" created
+clusterrolebinding "falco-cluster-role-binding" created
+k8s-using-daemonset$
+```
+
+The Daemon Set also relies on a Kubernetes ConfigMap to store the Falco configuration and make the configuration available to the Falco Pods. This allows you to manage custom configuration without rebuilding and redeploying the underlying Pods. In order to create the ConfigMap you'll need to first need to copy the required configuration from their location in this GitHub repo to the `k8s-with-rbac/falco-config/` directory. Any modification of the configuration should be performed on these copies rather than the original files.
+
+```
+k8s-using-daemonset$ cp ../../falco.yaml k8s-with-rbac/falco-config/
+k8s-using-daemonset$ cp ../../rules/falco_rules.* k8s-with-rbac/falco-config/
+```
+
+If you want to send Falco alerts to a Slack channel, you'll want to modify the `falco.yaml` file to point to your Slack webhook. For more information on getting a webhook URL for your Slack team, refer to the [Slack documentation](https://api.slack.com/incoming-webhooks). Add the below to the bottom of the `falco.yaml` config file you just copied to enable Slack messages.
+
+```
+program_output:
+  enabled: true
+  keep_alive: false
+  program: "jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/see_your_slack_team/apps_settings_for/a_webhook_url"
+```
+
+You will also need to enable JSON output. Find the `json_output: false` setting in the `falco.yaml` file and change it to read `json_output: true`. Any custom rules for your environment can be added to into the `falco_rules.local.yaml` file and they will be picked up by Falco at start time. You can now create the ConfigMap in Kubernetes. 
+
+```
+k8s-using-daemonset$ kubectl create configmap falco-config --from-file=k8s-with-rbac/
+configmap "falco-config" created
+k8s-using-daemonset$
+```
+
+Now that we have the requirements for our Daemon Set in place, we can create our Daemon Set.
+
+```
+k8s-using-daemonset$ kubectl create -f k8s-with-rbac/falco-daemonset-configmap.yaml 
+daemonset "falco" created
+k8s-using-daemonset$
+```
+
+
+## Deploying to Kubernetes without RBAC enabled
+
+If you are running Kubernetes with Legacy Authorization enabled, you can use `kubectl` to deploy the Daemon Set provided in the `k8s-without-rbac` directory. The example provides the ability to post messages to a Slack channel via a webhook. For more information on getting a webhook URL for your Slack team, refer to the [Slack documentation](https://api.slack.com/incoming-webhooks). Modify the [`args`](https://github.com/draios/falco/blob/dev/examples/k8s-using-daemonset/falco-daemonset.yaml#L21) passed to the Falco container to point to the appropriate URL for your webhook.
+
+```
+k8s-using-daemonset$ kubectl create -f k8s-without-rbac/falco-daemonset.yaml
+```
+
+
+## Verifying the installation
+
+In order to test that Falco is working correctly, you can launch a shell in a Pod. You should see a message in your Slack channel (if configured), or in the logs of the Falco pod.
+
+```
+k8s-using-daemonset$ kubectl get pods
+NAME          READY     STATUS    RESTARTS   AGE
+falco-74htl   1/1       Running   0          13h
+falco-fqz2m   1/1       Running   0          13h
+falco-sgjfx   1/1       Running   0          13h
+k8s-using-daemonset$ kubectl exec -it falco-74htl bash
+root@falco-74htl:/# exit
+k8s-using-daemonset$ kubectl logs falco-74htl
+{"output":"17:48:58.590038385: Notice A shell was spawned in a container with an attached terminal (user=root k8s.pod=falco-74htl container=a98c2aa8e670 shell=bash parent=<NA> cmdline=bash  terminal=34816)","priority":"Notice","rule":"Terminal shell in container","time":"2017-12-20T17:48:58.590038385Z", "output_fields": {"container.id":"a98c2aa8e670","evt.time":1513792138590038385,"k8s.pod.name":"falco-74htl","proc.cmdline":"bash ","proc.name":"bash","proc.pname":null,"proc.tty":34816,"user.name":"root"}}
+k8s-using-daemonset$
+``` 
+
+Alternatively, you can deploy the [Falco Event Generator](https://github.com/draios/falco/wiki/Generating-Sample-Events) deployement to have events automatically generated. Please note that this Deployment will generate a large number of events. 
+
+```
+k8s-using-daemonset$ kubectl create -f falco-event-generator-deployment.yaml \
+&& sleep 1 \
+&& kubectl delete -f falco-event-generator-deployment.yaml
+deployment "falco-event-generator-deployment" created
+deployment "falco-event-generator-deployment" deleted
+k8s-using-daemonset$ 
+```

--- a/examples/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml
+++ b/examples/k8s-using-daemonset/k8s-with-rbac/falco-account.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: falco-account
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: falco-cluster-role
+rules:
+  - apiGroups: ["extensions",""]
+    resources: ["nodes","namespaces","pods","replicationcontrollers","services","events","configmaps"]
+    verbs: ["get","list","watch"]
+  - nonResourceURLs: ["/healthz", "/healthz/*"]
+    verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: falco-cluster-role-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: falco-account
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: falco-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
+++ b/examples/k8s-using-daemonset/k8s-with-rbac/falco-daemonset-configmap.yaml
@@ -13,12 +13,13 @@ spec:
         app: demo
         role: security
     spec:
+      serviceAccount: falco-account
       containers:
         - name: falco
           image: sysdig/falco:latest
           securityContext:
             privileged: true
-          args: [ "/usr/bin/falco", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://kubernetes", "-pk", "-o", "json_output=true", "-o", "program_output.enabled=true", "-o",  "program_output.program=jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/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"]
+          args: [ "/usr/bin/falco", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://kubernetes", "-pk"]
           volumeMounts:
             - mountPath: /host/var/run/docker.sock
               name: docker-socket
@@ -38,6 +39,8 @@ spec:
             - mountPath: /host/usr
               name: usr-fs
               readOnly: true
+            - mountPath: /etc/falco
+              name: falco-config
       volumes:
         - name: docker-socket
           hostPath:
@@ -57,3 +60,6 @@ spec:
         - name: usr-fs
           hostPath:
             path: /usr
+        - name: falco-config
+          configMap:
+            name: falco-config

--- a/examples/k8s-using-daemonset/k8s-without-rbac/falco-daemonset.yaml
+++ b/examples/k8s-using-daemonset/k8s-without-rbac/falco-daemonset.yaml
@@ -1,0 +1,59 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: falco
+  labels:
+    name: falco-daemonset
+    app: demo
+spec:
+  template:
+    metadata:
+      labels:
+        name: falco
+        app: demo
+        role: security
+    spec:
+      containers:
+        - name: falco
+          image: sysdig/falco:latest
+          securityContext:
+            privileged: true
+          args: [ "/usr/bin/falco", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://kubernetes", "-pk", "-o", "json_output=true", "-o", "program_output.enabled=true", "-o",  "program_output.program=jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/see_your_slack_team/apps_settings_for/a_webhook_url"]
+          volumeMounts:
+            - mountPath: /host/var/run/docker.sock
+              name: docker-socket
+              readOnly: true
+            - mountPath: /host/dev
+              name: dev-fs
+              readOnly: true
+            - mountPath: /host/proc
+              name: proc-fs
+              readOnly: true
+            - mountPath: /host/boot
+              name: boot-fs
+              readOnly: true
+            - mountPath: /host/lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /host/usr
+              name: usr-fs
+              readOnly: true
+      volumes:
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+        - name: dev-fs
+          hostPath:
+            path: /dev
+        - name: proc-fs
+          hostPath:
+            path: /proc
+        - name: boot-fs
+          hostPath:
+            path: /boot
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: usr-fs
+          hostPath:
+            path: /usr


### PR DESCRIPTION
Updated the Kubernetes example to provide an additional example: Daemon Set using RBAC and a ConfigMap for configuration. Also expanded the documentation for both the RBAC and non-RBAC examples.