### PR TITLE
Add Rule for unexpected udp traffic

### DIFF
--- a/docker/event-generator/event_generator.cpp
+++ b/docker/event-generator/event_generator.cpp
@@ -296,22 +296,20 @@ void system_user_interactive() {
 }
 
 void network_activity() {
-	printf("Opening a listening socket on port 8192...\n");
+	printf("Connecting a udp socket to 10.2.3.4:8192...\n");
 	int rc;
 	int sock = socket(PF_INET, SOCK_DGRAM, 0);
 	struct sockaddr_in localhost;
 
 	localhost.sin_family = AF_INET;
 	localhost.sin_port = htons(8192);
-	inet_aton("127.0.0.1", &(localhost.sin_addr));
+	inet_aton("10.2.3.4", &(localhost.sin_addr));
 
-	if((rc = bind(sock, (struct sockaddr *) &localhost, sizeof(localhost))) != 0)
+	if((rc = connect(sock, (struct sockaddr *) &localhost, sizeof(localhost))) != 0)
 	{
 		fprintf(stderr, "Could not bind listening socket to localhost: %s\n", strerror(errno));
 		return;
 	}
-
-	listen(sock, 1);
 
 	close(sock);
 }

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1344,14 +1344,29 @@
 - list: statsd_ports
   items: [8125]
 
+- list: mysql_ports
+  items: [3306]
+
+- list: ntp_ports
+  items: [123]
+
+# 0 is included in the list because some apps connect to an address
+# only to test connectivity.
+#
+# mysql_ports is included becuase some versions of the mysql client
+# will attempt a connect using udp + port 3306 before connecting via
+# tcp + port 3306.
+#
+# 80 is included for the same reason as mysql_ports--some apps do a
+# connect using udp before doing a real connect using tcp.
 - list: expected_udp_ports
-  items: [53, openvpn_udp_ports, l2tp_udp_ports, statsd_ports]
+  items: [0, 53, 80, openvpn_udp_ports, l2tp_udp_ports, statsd_ports, mysql_ports, ntp_ports]
 
 - macro: expected_udp_traffic
-  condition: fd.sport in (expected_udp_ports)
+  condition: fd.port in (expected_udp_ports)
 
 - rule: Unexpected UDP Traffic
-  desc: UDP traffic not on port 53 (DNS) or commonly used VPN Ports
+  desc: UDP traffic not on port 53 (DNS) or other commonly used ports
   condition: (inbound_outbound) and fd.l4proto=udp and not expected_udp_traffic
   output: >
     Unexpected UDP Traffic Seen

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -245,15 +245,22 @@
 # Network
 - macro: inbound
   condition: >
-    ((evt.type in (accept,listen) and evt.dir=<) or
-     (evt.type in (recvfrom,recvmsg) and fd.l4proto = udp and fd.name_changed=true) and
-      (fd.typechar = 4 or fd.typechar = 6))
+    (((evt.type in (accept,listen) and evt.dir=<) or
+      (evt.type in (recvfrom,recvmsg) and evt.dir=< and
+       fd.l4proto != tcp and fd.connected=false and fd.name_changed=true)) and
+     (fd.typechar = 4 or fd.typechar = 6) and
+     (fd.ip != "0.0.0.0" and fd.net != "127.0.0.0/8") and
+     (evt.rawres >= 0 or evt.res = EINPROGRESS))
 
 - macro: outbound
   condition: >
-    ((evt.type = connect and evt.dir=<) or
-     (evt.type in (sendto,sendmsg) and fd.l4proto = udp and fd.name_changed=true) and
-     (fd.typechar = 4 or fd.typechar = 6))
+    (((evt.type = connect and evt.dir=<) or
+      (evt.type in (sendto,sendmsg) and evt.dir=< and
+       fd.l4proto != tcp and fd.connected=false and fd.name_changed=true)) and
+     (fd.typechar = 4 or fd.typechar = 6) and
+     (fd.ip != "0.0.0.0" and fd.net != "127.0.0.0/8") and
+     (evt.rawres >= 0 or evt.res = EINPROGRESS))
+
 
 - macro: ssh_port
   condition: fd.sport=22
@@ -719,7 +726,7 @@
     and not proc.pname in (sysdigcloud_binaries, mail_config_binaries, hddtemp.postins, sshkit_script_binaries, locales.postins, deb_binaries, dhcp_binaries)
     and not fd.name pmatch (safe_etc_dirs)
     and not fd.name in (/etc/container_environment.sh, /etc/container_environment.json, /etc/motd, /etc/motd.svc)
-    and not exe_running_docker_save    
+    and not exe_running_docker_save
     and not ansible_running_python
     and not python_running_denyhosts
     and not fluentd_writing_conf_files

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -244,12 +244,16 @@
 
 # Network
 - macro: inbound
-  condition: ((evt.type=listen and evt.dir=>) or (evt.type=accept and evt.dir=<))
+  condition: >
+    ((evt.type in (accept,listen) and evt.dir=<) or
+     (evt.type in (recvfrom,recvmsg) and fd.l4proto = udp and fd.name_changed=true) and
+      (fd.typechar = 4 or fd.typechar = 6))
 
-# Currently sendto is an ignored syscall, otherwise this could also
-# check for (evt.type=sendto and evt.dir=>)
 - macro: outbound
-  condition: evt.type=connect and evt.dir=< and (fd.typechar=4 or fd.typechar=6)
+  condition: >
+    ((evt.type = connect and evt.dir=<) or
+     (evt.type in (sendto,sendmsg) and fd.l4proto = udp and fd.name_changed=true) and
+     (fd.typechar = 4 or fd.typechar = 6))
 
 - macro: ssh_port
   condition: fd.sport=22

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -1314,6 +1314,30 @@
   priority: NOTICE
   tags: [network]
 
+- list: openvpn_udp_ports
+  items: [1194, 1197, 1198, 8080, 9201]
+
+- list: l2tp_udp_ports
+  items: [500, 1701, 4500, 10000]
+
+- list: statsd_ports
+  items: [8125]
+
+- list: expected_udp_ports
+  items: [53, openvpn_udp_ports, l2tp_udp_ports, statsd_ports]
+
+- macro: expected_udp_traffic
+  condition: fd.sport in (expected_udp_ports)
+
+- rule: Unexpected UDP Traffic
+  desc: UDP traffic not on port 53 (DNS) or commonly used VPN Ports
+  condition: (inbound or outbound) and fd.l4proto=udp and not expected_udp_traffic
+  output: >
+    Unexpected UDP Traffic Seen
+    (user=%user.name command=%proc.cmdline connection=%fd.name proto=%fd.l4proto)
+  priority: NOTICE
+  tags: [network]
+
 # With the current restriction on system calls handled by falco
 # (e.g. excluding read/write/sendto/recvfrom/etc, this rule won't
 # trigger).

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -261,6 +261,16 @@
      (fd.ip != "0.0.0.0" and fd.net != "127.0.0.0/8") and
      (evt.rawres >= 0 or evt.res = EINPROGRESS))
 
+# Very similar to inbound/outbound, but combines the tests together
+# for efficiency.
+- macro: inbound_outbound
+  condition: >
+    (((evt.type in (accept,listen,connect) and evt.dir=<) or
+      (evt.type in (recvfrom,recvmsg,sendto,sendmsg) and evt.dir=< and
+       fd.l4proto != tcp and fd.connected=false and fd.name_changed=true)) and
+     (fd.typechar = 4 or fd.typechar = 6) and
+     (fd.ip != "0.0.0.0" and fd.net != "127.0.0.0/8") and
+     (evt.rawres >= 0 or evt.res = EINPROGRESS))
 
 - macro: ssh_port
   condition: fd.sport=22
@@ -280,7 +290,7 @@
 
 - rule: Disallowed SSH Connection
   desc: Detect any new ssh connection to a host other than those in an allowed group of hosts
-  condition: (outbound or inbound) and ssh_port and not allowed_ssh_hosts
+  condition: (inbound_outbound) and ssh_port and not allowed_ssh_hosts
   output: Disallowed SSH Connection (command=%proc.cmdline connection=%fd.name user=%user.name)
   priority: NOTICE
   tags: [network]
@@ -1316,7 +1326,7 @@
   desc: any network activity performed by system binaries that are not expected to send or receive any network traffic
   condition: >
     (fd.sockfamily = ip and system_procs)
-    and (inbound or outbound)
+    and (inbound_outbound)
     and not proc.name in (systemd, hostid)
     and not login_doing_dns_lookup
   output: >
@@ -1342,7 +1352,7 @@
 
 - rule: Unexpected UDP Traffic
   desc: UDP traffic not on port 53 (DNS) or commonly used VPN Ports
-  condition: (inbound or outbound) and fd.l4proto=udp and not expected_udp_traffic
+  condition: (inbound_outbound) and fd.l4proto=udp and not expected_udp_traffic
   output: >
     Unexpected UDP Traffic Seen
     (user=%user.name command=%proc.cmdline connection=%fd.name proto=%fd.l4proto)
@@ -1499,7 +1509,7 @@
 
 - rule: Unexpected K8s NodePort Connection
   desc: Detect attempts to use K8s NodePorts from a container
-  condition: (outbound or inbound) and fd.sport >= 30000 and fd.sport <= 32767 and container and not nodeport_containers
+  condition: (inbound_outbound) and fd.sport >= 30000 and fd.sport <= 32767 and container and not nodeport_containers
   output: Unexpected K8s NodePort Connection (command=%proc.cmdline connection=%fd.name)
   priority: NOTICE
   tags: [network, k8s, container]


### PR DESCRIPTION
New rule Unexpected UDP Traffic checks for udp traffic not on a list of
expected ports. Currently blocked on
https://github.com/draios/falco/issues/308.