### PR TITLE
Add user_known_change_thread_namespace_binaries

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -984,6 +984,12 @@
 #     syscall=%evt.type args=%evt.args)
 #   priority: INFO
 
+# This list allows for easy additions to the set of commands allowed
+# to change thread namespace without having to copy and override the
+# entire change thread namespace rule.
+- list: user_known_change_thread_namespace_binaries
+  items: []
+
 - rule: Change thread namespace
   desc: >
     an attempt to change a program/thread\'s namespace (commonly done
@@ -991,6 +997,7 @@
   condition: >
     evt.type = setns
     and not proc.name in (docker_binaries, k8s_binaries, lxd_binaries, sysdigcloud_binaries, sysdig, nsenter)
+    and not proc.name in (user_known_change_thread_namespace_binaries)
     and not proc.name startswith "runc:"
     and not proc.pname in (sysdigcloud_binaries)
     and not java_running_sdjagent


### PR DESCRIPTION
Add the user_known_change_thread_namespace_binaries list to simplify the "Change thread namespace" rule tweaks.

This can be very useful to modify the "Change thread namespace" from the `falco_rules.local.yaml` file without copying the entire rule. I will use this new array to whitelist `calico`, our overlay network in our Kubernetes cluster, which was raising:
```JSON
{
    "output": "15:18:23.416545428: Notice Namespace change (setns) by unexpected program (user=root command=calico  parent=calico k8s.pod=<NA> container=host)",
    "priority": "Notice",
    "rule": "Change thread namespace",
    "time": "2018-02-19T15:18:23.416545428Z",
    "output_fields": {
        "container.id": "host",
        "evt.time": 1519053503416545428,
        "k8s.pod.name": null,
        "proc.cmdline": "calico ",
        "proc.pname": "calico",
        "user.name": "root"
    }
}
```