### PR TITLE
Example puppet module for falco

### DIFF
--- a/examples/puppet-module/README.md
+++ b/examples/puppet-module/README.md
@@ -1,0 +1,3 @@
+# Example Puppet Falco Module
+
+This contains an example [Puppet](https://puppet.com/) module for Falco.

--- a/examples/puppet-module/sysdig-falco/Gemfile
+++ b/examples/puppet-module/sysdig-falco/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppet-lint', '>= 0.3.2'
+gem 'facter', '>= 1.7.0'

--- a/examples/puppet-module/sysdig-falco/README.md
+++ b/examples/puppet-module/sysdig-falco/README.md
@@ -1,0 +1,241 @@
+# falco
+
+#### Table of Contents
+
+1. [Overview](#overview)
+2. [Module Description - What the module does and why it is useful](#module-description)
+3. [Setup - The basics of getting started with falco](#setup)
+    * [What falco affects](#what-falco-affects)
+    * [Beginning with falco](#beginning-with-falco)
+4. [Usage - Configuration options and additional functionality](#usage)
+5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+5. [Limitations - OS compatibility, etc.](#limitations)
+6. [Development - Guide for contributing to the module](#development)
+
+## Overview
+
+Sysdig Falco is a behavioral activity monitor designed to detect anomalous activity in your applications. Powered by sysdig’s system call capture infrastructure, falco lets you continuously monitor and detect container, application, host, and network activity... all in one place, from one source of data, with one set of rules.
+
+#### What kind of behaviors can Falco detect?
+
+Falco can detect and alert on any behavior that involves making Linux system calls. Thanks to Sysdig's core decoding and state tracking functionality, falco alerts can be triggered by the use of specific system calls, their arguments, and by properties of the calling process. For example, you can easily detect things like:
+
+- A shell is run inside a container
+- A container is running in privileged mode, or is mounting a sensitive path like `/proc` from the host.
+- A server process spawns a child process of an unexpected type
+- Unexpected read of a sensitive file (like `/etc/shadow`)
+- A non-device file is written to `/dev`
+- A standard system binary (like `ls`) makes an outbound network connection
+
+## Module Description
+
+This module configures falco as a systemd service. You configure falco
+to send its notifications to one or more output channels (syslog,
+files, programs).
+
+## Setup
+
+### What falco affects
+
+This module affects the following:
+
+* The main falco configuration file `/etc/falco/falco.yaml`, including
+** Output format (JSON vs plain text)
+** Log level
+** Rule priority level to run
+** Output buffering
+** Output throttling
+** Output channels (syslog, file, program)
+
+### Beginning with falco
+
+To have Puppet install falco with the default parameters, declare the falco class:
+
+``` puppet
+class { 'falco': }
+```
+
+When you declare this class with the default options, the module:
+
+* Installs the appropriate falco software package and installs the falco-probe kernel module for your operating system.
+* Creates the required configuration file `/etc/falco/falco.yaml`. By default only syslog output is enabled.
+* Starts the falco service.
+
+## Usage
+
+### Enabling file output
+
+To enable file output, set the `file_output` hash, as follows:
+
+``` puppet
+class { 'falco':
+  file_output => {
+    'enabled' => 'true',
+    'keep_alive' => 'false',
+	'filename' => '/tmp/falco-events.txt'
+  },
+}
+```
+
+### Enabling program output
+
+To enable program output, set the `program_output` hash and optionally the `json_output` parameters, as follows:
+
+``` puppet
+class { 'falco':
+  json_output => 'true',
+  program_output => {
+    'enabled' => 'true',
+    'keep_alive' => 'false',
+	'program' => 'curl http://some-webhook.com'
+  },
+}
+```
+
+## Reference
+
+* [**Public classes**](#public-classes)
+    * [Class: falco](#class-falco)
+
+### Public Classes
+
+#### Class: `falco`
+
+Guides the basic setup and installation of falco on your system.
+
+When this class is declared with the default options, Puppet:
+
+* Installs the appropriate falco software package and installs the falco-probe kernel module for your operating system.
+* Creates the required configuration file `/etc/falco/falco.yaml`. By default only syslog output is enabled.
+* Starts the falco service.
+
+You can simply declare the default `falco` class:
+
+``` puppet
+class { 'falco': }
+```
+
+###### `rules_file`
+
+An array of files for falco to load. Order matters--the first file listed will be loaded first.
+
+Default: `['/etc/falco/falco_rules.yaml', '/etc/falco/falco_rules.local.yaml']`
+
+##### `json_output`
+
+Whether to output events in json or text.
+
+Default: `false`
+
+##### `log_stderr`
+
+Send falco's logs to stderr. Note: this is not notifications, this is
+logs from the falco daemon itself.
+
+Default: `false`
+
+##### `log_syslog`
+
+Send falco's logs to syslog. Note: this is not notifications, this is
+logs from the falco daemon itself.
+
+Default: `true`
+
+##### `log_level`
+
+Minimum log level to include in logs. Note: these levels are
+separate from the priority field of rules. This refers only to the
+log level of falco's internal logging. Can be one of "emergency",
+"alert", "critical", "error", "warning", "notice", "info", "debug".
+
+Default: `info`
+
+##### `priority`
+
+Minimum rule priority level to load and run. All rules having a
+priority more severe than this level will be loaded/run.  Can be one
+of "emergency", "alert", "critical", "error", "warning", "notice",
+"info", "debug".
+
+Default: `debug`
+
+##### `buffered_outputs`
+
+Whether or not output to any of the output channels below is
+buffered.
+
+Default: `true`
+
+##### `outputs_rate`/`outputs_max_burst`
+
+A throttling mechanism implemented as a token bucket limits the
+rate of falco notifications. This throttling is controlled by the following configuration
+options:
+
+* `outputs_rate`: the number of tokens (i.e. right to send a notification)
+   gained per second. Defaults to 1.
+* `outputs_max_burst`: the maximum number of tokens outstanding. Defaults to 1000.
+
+##### `syslog_output
+
+Controls syslog output for notifications. Value: a hash, containing the following:
+
+* `enabled`: `true` or `false`. Default: `true`.
+
+Example:
+
+``` puppet
+class { 'falco':
+  syslog_output => {
+    'enabled' => 'true',
+  },
+}
+```
+
+##### `file_output`
+
+Controls file output for notifications. Value: a hash, containing the following:
+
+* `enabled`: `true` or `false`. Default: `false`.
+* `keep_alive`: If keep_alive is set to true, the file will be opened once and continuously written to, with each output message on its own line. If keep_alive is set to false, the file will be re-opened for each output message. Default: `false`.
+* `filename`: Notifications will be written to this file.
+
+Example:
+
+``` puppet
+class { 'falco':
+  file_output => {
+    'enabled' => 'true',
+    'keep_alive' => 'false',
+	'filename' => '/tmp/falco-events.txt'
+  },
+}
+```
+
+##### `program_output
+
+Controls program output for notifications. Value: a hash, containing the following:
+
+* `enabled`: `true` or `false`. Default: `false`.
+* `keep_alive`: If keep_alive is set to true, the file will be opened once and continuously written to, with each output message on its own line. If keep_alive is set to false, the file will be re-opened for each output message. Default: `false`.
+* `program`: Notifications will be written to this program.
+
+Example:
+
+``` puppet
+class { 'falco':
+  program_output => {
+    'enabled' => 'true',
+    'keep_alive' => 'false',
+	'program' => 'curl http://some-webhook.com'
+  },
+}
+```
+
+## Limitations
+
+The module works where falco works as a daemonized service (generally, Linux only).
+
+## Development
+
+For more information on Sysdig Falco, visit our [github](https://github.com/draios/falco) or [web site](https://sysdig.com/opensource/falco/).

--- a/examples/puppet-module/sysdig-falco/Rakefile
+++ b/examples/puppet-module/sysdig-falco/Rakefile
@@ -1,0 +1,18 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Validate manifests, templates, and ruby files"
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end

--- a/examples/puppet-module/sysdig-falco/manifests/config.pp
+++ b/examples/puppet-module/sysdig-falco/manifests/config.pp
@@ -1,0 +1,13 @@
+# == Class: falco::config
+class falco::config inherits falco {
+
+  file { '/etc/falco/falco.yaml':
+    notify  => Service['falco'],
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('falco/falco.yaml.erb'),
+  }
+
+}

--- a/examples/puppet-module/sysdig-falco/manifests/init.pp
+++ b/examples/puppet-module/sysdig-falco/manifests/init.pp
@@ -1,0 +1,31 @@
+class falco (
+          $rules_file = [
+              '/etc/falco/falco_rules.yaml',
+              '/etc/falco/falco_rules.local.yaml'
+          ],
+          $json_output = 'false',
+          $log_stderr = 'false',
+          $log_syslog = 'true',
+          $log_level = 'info',
+          $priority = 'debug',
+          $buffered_outputs = 'true',
+          $outputs_rate = 1,
+          $outputs_max_burst = 1000,
+          $syslog_output = {
+              'enabled' => 'true'
+          },
+          $file_output = {
+              'enabled' => 'false',
+              'keep_alive' => 'false',
+              'filename' => '/tmp/falco_events.txt'
+          },
+          $program_output = {
+              'enabled' => 'false',
+              'keep_alive' => 'false',
+              'program' => 'curl http://some-webhook.com'
+          },
+      ) {
+  include falco::install
+  include falco::config
+  include falco::service
+}

--- a/examples/puppet-module/sysdig-falco/manifests/install.pp
+++ b/examples/puppet-module/sysdig-falco/manifests/install.pp
@@ -1,0 +1,6 @@
+# == Class: falco::install
+class falco::install inherits falco {
+  package { 'falco':
+      ensure => installed,
+  }
+}

--- a/examples/puppet-module/sysdig-falco/manifests/service.pp
+++ b/examples/puppet-module/sysdig-falco/manifests/service.pp
@@ -1,0 +1,11 @@
+# == Class: falco::service
+class falco::service inherits falco {
+
+  service { 'falco':
+    ensure     => running,
+    enable     => true,
+    hasstatus  => true,
+    hasrestart => true,
+    require => Package['falco'],
+  }
+}

--- a/examples/puppet-module/sysdig-falco/metadata.json
+++ b/examples/puppet-module/sysdig-falco/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "sysdig-falco",
+  "version": "0.1.0",
+  "author": "sysdig",
+  "summary": "Sysdig Falco: Behavioral Activity Monitoring With Container Support",
+  "license": "GPLv2",
+  "source": "https://github.com/draios/falco",
+  "project_page": "https://github.com/draios/falco",
+  "issues_url": "https://github.com/draios/falco/issues",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
+}
+

--- a/examples/puppet-module/sysdig-falco/spec/classes/init_spec.rb
+++ b/examples/puppet-module/sysdig-falco/spec/classes/init_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+describe 'falco' do
+
+  context 'with defaults for all parameters' do
+    it { should contain_class('falco') }
+  end
+end

--- a/examples/puppet-module/sysdig-falco/spec/spec_helper.rb
+++ b/examples/puppet-module/sysdig-falco/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/examples/puppet-module/sysdig-falco/templates/falco.yaml.erb
+++ b/examples/puppet-module/sysdig-falco/templates/falco.yaml.erb
@@ -1,0 +1,96 @@
+####
+# THIS FILE MANAGED BY PUPPET. DO NOT MODIFY
+####
+
+# File(s) containing Falco rules, loaded at startup.
+#
+# falco_rules.yaml ships with the falco package and is overridden with
+# every new software version. falco_rules.local.yaml is only created
+# if it doesn't exist. If you want to customize the set of rules, add
+# your customizations to falco_rules.local.yaml.
+#
+# The files will be read in the order presented here, so make sure if
+# you have overrides they appear in later files.
+rules_file:
+<% Array(@rules_file).each do |file| -%>
+ - <%= file %>
+<% end -%>
+
+# Whether to output events in json or text
+json_output: <%= @json_output %>
+
+# Send information logs to stderr and/or syslog Note these are *not* security
+# notification logs! These are just Falco lifecycle (and possibly error) logs.
+log_stderr: <%= @log_stderr %>
+log_syslog: <%= @log_syslog %>
+
+# Minimum log level to include in logs. Note: these levels are
+# separate from the priority field of rules. This refers only to the
+# log level of falco's internal logging. Can be one of "emergency",
+# "alert", "critical", "error", "warning", "notice", "info", "debug".
+log_level: <%= @log_level %>
+
+# Minimum rule priority level to load and run. All rules having a
+# priority more severe than this level will be loaded/run.  Can be one
+# of "emergency", "alert", "critical", "error", "warning", "notice",
+# "info", "debug".
+priority: <%= @priority %>
+
+# Whether or not output to any of the output channels below is
+# buffered. Defaults to true
+buffered_outputs: <%= @buffered_outputs %>
+
+# A throttling mechanism implemented as a token bucket limits the
+# rate of falco notifications. This throttling is controlled by the following configuration
+# options:
+#  - rate: the number of tokens (i.e. right to send a notification)
+#    gained per second. Defaults to 1.
+#  - max_burst: the maximum number of tokens outstanding. Defaults to 1000.
+#
+# With these defaults, falco could send up to 1000 notifications after
+# an initial quiet period, and then up to 1 notification per second
+# afterward. It would gain the full burst back after 1000 seconds of
+# no activity.
+
+outputs:
+  rate: <%= @outputs_rate %>
+  max_burst: <%= @outputs_max_burst %>
+
+# Where security notifications should go.
+# Multiple outputs can be enabled.
+<% unless @syslog_output.nil? -%>
+syslog_output:
+  enabled: <%= @syslog_output['enabled'] %>
+<% end -%>
+
+# If keep_alive is set to true, the file will be opened once and
+# continuously written to, with each output message on its own
+# line. If keep_alive is set to false, the file will be re-opened
+# for each output message.
+<% unless @file_output.nil? -%>
+file_output:
+  enabled: <%= @file_output['enabled'] %>
+  keep_alive: <%= @file_output['keep_alive'] %>
+  filename: <%= @file_output['filename'] %>
+<% end -%>
+
+# Possible additional things you might want to do with program output:
+#   - send to a slack webhook:
+#         program: "jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/XXX"
+#   - logging (alternate method than syslog):
+#         program: logger -t falco-test
+#   - send over a network connection:
+#         program: nc host.example.com 80
+
+# If keep_alive is set to true, the program will be started once and
+# continuously written to, with each output message on its own
+# line. If keep_alive is set to false, the program will be re-spawned
+# for each output message.
+
+<% unless @program_output.nil? -%>
+program_output:
+  enabled: <%= @program_output['enabled'] %>
+  keep_alive: <%= @program_output['keep_alive'] %>
+  program: <%= @program_output['program'] %>
+<% end -%>
+

--- a/examples/puppet-module/sysdig-falco/tests/init.pp
+++ b/examples/puppet-module/sysdig-falco/tests/init.pp
@@ -1,0 +1,12 @@
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here:
+# http://docs.puppetlabs.com/guides/tests_smoke.html
+#
+include falco


### PR DESCRIPTION
Add an example puppet module for falco. This module configures the main
falco configuration file /etc/falco/falco.yaml, providing templates for
all configuration options.

It installs falco using debian/rpm packages and installs/manages it as a
systemd service.

This fixes https://github.com/draios/falco/issues/115.