### PR TITLE
Start setting autodrop, which filters addl events

### DIFF
--- a/userspace/falco/falco.cpp
+++ b/userspace/falco/falco.cpp
@@ -574,6 +574,7 @@ int falco_init(int argc, char **argv)
 		if(!all_events)
 		{
 			inspector->set_drop_event_flags(EF_DROP_FALCO);
+			inspector->start_dropping_mode(1);
 		}
 
 		if (describe_all_rules)


### PR DESCRIPTION
To further reduce falco's cpu usage, start setting the inspector in
"autodrop" mode with a sampling ratio of 1. When autodrop mode is
enabled, a second class of events (those having EF_ALWAYS_DROP in the
syscall table, or those syscalls that do not have specific handling in
the syscall table) are also excluded.