### PR TITLE
Fix/Expand "Modify bin dirs" rule

### DIFF
--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -39,6 +39,13 @@
 - macro: bin_dir
   condition: fd.directory in (/bin, /sbin, /usr/bin, /usr/sbin)
 
+- macro: bin_dir_resolved
+  condition: >
+    (evt.abspath startswith /bin/ or
+     evt.abspath startswith /sbin/ or
+     evt.abspath startswith /usr/bin/ or
+     evt.abspath startswith /usr/sbin/)
+
 - macro: bin_dir_mkdir
   condition: >
     (evt.arg[1] startswith /bin/ or
@@ -926,7 +933,7 @@
 
 - rule: Modify binary dirs
   desc: an attempt to modify any file below a set of binary directories.
-  condition: bin_dir_rename and modify and not package_mgmt_procs and not exe_running_docker_save
+  condition: (bin_dir_rename or bin_dir_resolved) and modify and not package_mgmt_procs and not exe_running_docker_save
   output: >
     File below known binary directory renamed/removed (user=%user.name command=%proc.cmdline
     operation=%evt.type file=%fd.name %evt.args)

--- a/rules/falco_rules.yaml
+++ b/rules/falco_rules.yaml
@@ -23,7 +23,7 @@
   condition: (proc.name!="<NA>")
 
 - macro: rename
-  condition: evt.type = rename
+  condition: evt.type in (rename, renameat)
 - macro: mkdir
   condition: evt.type = mkdir
 - macro: remove


### PR DESCRIPTION
- To monitor file/dirs removed with `unlinkat` we need to check `evt.abspath`, not `evt.arg[1]`
- Monitor `renameat` too