### PR TITLE
Add tests catchall order

### DIFF
--- a/test/falco_test.py
+++ b/test/falco_test.py
@@ -213,7 +213,7 @@ class FalcoTest(Test):
         triggered_rules = match.group(1)
 
         for rule, count in self.detect_counts.iteritems():
-            expected = '{}: (\d+)'.format(rule)
+            expected = '\s{}: (\d+)'.format(rule)
             match = re.search(expected, triggered_rules)
 
             if match is None:

--- a/test/falco_tests.yaml
+++ b/test/falco_tests.yaml
@@ -699,3 +699,13 @@ trace_files: !mux
       - detect_madvise: 2
       - detect_open: 2
     trace_file: trace_files/syscall.scap
+
+  catchall_order:
+    detect: True
+    detect_level: INFO
+    rules_file:
+      - rules/catchall_order.yaml
+    detect_counts:
+      - open_dev_null: 1
+        dev_null: 0
+    trace_file: trace_files/cat_write.scap

--- a/test/rules/catchall_order.yaml
+++ b/test/rules/catchall_order.yaml
@@ -1,0 +1,12 @@
+- rule: open_dev_null
+  desc: Any open of the file /dev/null
+  condition: evt.type=open and fd.name=/dev/null
+  output: An open of /dev/null was seen (command=%proc.cmdline evt=%evt.type %evt.args)
+  priority: INFO
+
+- rule: dev_null
+  desc: Anything related to /dev/null
+  condition: fd.name=/dev/null
+  output: Something related to /dev/null was seen (command=%proc.cmdline evt=%evt.type %evt.args)
+  priority: INFO
+  warn_evttypes: false

--- a/userspace/engine/lua/rule_loader.lua
+++ b/userspace/engine/lua/rule_loader.lua
@@ -373,8 +373,14 @@ function load_rules(rules_content, rules_mgr, verbose, all_events, extra, replac
 
       local v = state.rules_by_name[name]
 
+      warn_evttypes = true
+      if v['warn_evttypes'] ~= nil then
+	 warn_evttypes = v['warn_evttypes']
+      end
+
       local filter_ast, evttypes, syscallnums = compiler.compile_filter(v['rule'], v['condition'],
-								     state.macros, state.lists)
+									state.macros, state.lists,
+									warn_evttypes)
 
       if (filter_ast.type == "Rule") then
 	 state.n_rules = state.n_rules + 1


### PR DESCRIPTION
Testing fix for https://github.com/draios/falco/issues/354 as well as some other minor improvements that allow suppressing evttype warnings for a given rule.