### PR TITLE
Don't make driver compilation fail when kernel is compiled with CONFIG_ORC_UNWINDER or CONFIG_STACK_VALIDATION

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -17,13 +17,16 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
-	curl \
-	jq \
-	gnupg2 \
 	ca-certificates \
+	curl \
+	gnupg2 \
 	gcc \
 	gcc-5 \
-	gdb && rm -rf /var/lib/apt/lists/*
+	gdb \
+	jq \
+	libc6-dev \
+	libelf-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -17,13 +17,16 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
-	curl \
-	jq \
-	gnupg2 \
 	ca-certificates \
+	curl \
+	dkms \
+	gnupg2 \
 	gcc \
 	gcc-5 \
-	dkms && rm -rf /var/lib/apt/lists/*
+	jq \
+	libc6-dev \
+	libelf-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -17,12 +17,15 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
-	curl \
-	jq \
 	ca-certificates \
+	curl \
 	gnupg2 \
 	gcc \
-	gcc-5 && rm -rf /var/lib/apt/lists/*
+	gcc-5 \
+	jq \
+	libc6-dev \
+	libelf-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.


### PR DESCRIPTION
Propagating Dockerfile changes from https://github.com/draios/sysdig/commit/b1e94b81a4ea83f158f869ff7210e3be40ba92fe to the Dockerfiles in the falco repo per https://github.com/coreos/bugs/issues/2415#issuecomment-385498439.

This change adds `libc6-dev` and `libelf-dev` to the list of packages we apt-get install in the docker container for Falco. This is required for dynamic kernel module compilation on the latest CoreOS Container Linux.

Fixed up the ordering on the package names while in here (sorry for the noise).