### PR TITLE
eBPF support for Falco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - sudo apt-get update
 install:
     - sudo apt-get --force-yes install g++-4.8
-    - sudo apt-get install rpm linux-headers-$(uname -r)
+    - sudo apt-get install rpm linux-headers-$(uname -r) libelf-dev
     - git clone https://github.com/draios/sysdig.git ../sysdig
     - sudo apt-get install -y python-pip libvirt-dev jq dkms
     - cd ..

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -17,6 +17,8 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
+	bc \
+	clang-7 \
 	ca-certificates \
 	curl \
 	gnupg2 \
@@ -26,11 +28,17 @@ RUN apt-get update \
 	jq \
 	libc6-dev \
 	libelf-dev \
+	llvm-7 \
  && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.
 RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
+
+RUN rm -rf /usr/bin/clang \
+ && rm -rf /usr/bin/llc \
+ && ln -s /usr/bin/clang-7 /usr/bin/clang \
+ && ln -s /usr/bin/llc-7 /usr/bin/llc
 
 RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add - \
  && curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/$FALCO_REPOSITORY/deb/draios.list \

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -17,6 +17,8 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
+	bc \
+	clang-7 \
 	ca-certificates \
 	curl \
 	dkms \
@@ -26,11 +28,17 @@ RUN apt-get update \
 	jq \
 	libc6-dev \
 	libelf-dev \
+	llvm-7 \
  && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.
 RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
+
+RUN rm -rf /usr/bin/clang \
+ && rm -rf /usr/bin/llc \
+ && ln -s /usr/bin/clang-7 /usr/bin/clang \
+ && ln -s /usr/bin/llc-7 /usr/bin/llc
 
 RUN ln -s $SYSDIG_HOST_ROOT/lib/modules /lib/modules
 

--- a/docker/stable/Dockerfile
+++ b/docker/stable/Dockerfile
@@ -17,6 +17,8 @@ ADD http://download.draios.com/apt-draios-priority /etc/apt/preferences.d/
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
 	bash-completion \
+	bc \
+	clang-7 \
 	ca-certificates \
 	curl \
 	gnupg2 \
@@ -25,11 +27,17 @@ RUN apt-get update \
 	jq \
 	libc6-dev \
 	libelf-dev \
+	llvm-7 \
  && rm -rf /var/lib/apt/lists/*
 
 # Since our base Debian image ships with GCC 7 which breaks older kernels, revert the
 # default to gcc-5.
 RUN rm -rf /usr/bin/gcc && ln -s /usr/bin/gcc-5 /usr/bin/gcc
+
+RUN rm -rf /usr/bin/clang \
+ && rm -rf /usr/bin/llc \
+ && ln -s /usr/bin/clang-7 /usr/bin/clang \
+ && ln -s /usr/bin/llc-7 /usr/bin/llc
 
 RUN curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add - \
  && curl -s -o /etc/apt/sources.list.d/draios.list http://download.draios.com/$FALCO_REPOSITORY/deb/draios.list \


### PR DESCRIPTION
This PR supports eBPF for Falco. No special changes to the code are needed as long as Falco gets built with an eBPF-enabled libscap (now on sysdig/dev). One can simply set the environment variable `SYSDIG_BPF_PROBE` as described in https://github.com/draios/sysdig/wiki/eBPF-(beta) and everything will work:

```
gianluca@sid:~$ docker run -i -t --rm --name falco --privileged -v /var/run/docker.sock:/host/var/run/docker.sock -v /dev:/host/dev -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro --net=host -e SYSDIG_BPF_PROBE="" falco
* Setting up /usr/src links from host
* Mounting debugfs
Found kernel config at /host/boot/config-4.17.0-rc3+
* Trying to compile BPF probe falco-probe-bpf (falco-probe-bpf-0.1.1dev-x86_64-4.17.0-rc3+-0224696ca075f29c3b267198dbbd4a1c.o)
* BPF probe located, it's now possible to start sysdig
Wed May  9 17:22:35 2018: Falco initialized with configuration file /etc/falco/falco.yaml
Wed May  9 17:22:35 2018: Loading rules from file /etc/falco/falco_rules.yaml:
Wed May  9 17:22:35 2018: Loading rules from file /etc/falco/falco_rules.local.yaml:
17:22:37.159101504: Notice A shell was spawned in a container with an attached terminal (user=root practical_swanson (id=ddabdd12bf25) shell=bash parent=<NA> cmdline=bash  terminal=34831)
```

If we later need it, but I doubt it, we can patch the command line arguments to actually take a "--bpf" parameter to directly control the BPF probe path with sinsp.
