### PR TITLE
Add TBB dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,32 @@ else()
                 INSTALL_COMMAND sh -c "cp -R ${PROJECT_BINARY_DIR}/lyaml-prefix/src/lyaml/lib/* ${PROJECT_SOURCE_DIR}/userspace/engine/lua")
 endif()
 
+option(USE_BUNDLED_TBB "Enable building of the bundled tbb" ${USE_BUNDLED_DEPS})
+if(NOT USE_BUNDLED_TBB)
+	find_path(TBB_INCLUDE tbb.h PATH_SUFFIXES tbb)
+	find_library(TBB_LIB NAMES tbb)
+	if(TBB_INCLUDE AND TBB_LIB)
+		message(STATUS "Found tbb: include: ${TBB_INCLUDE}, lib: ${TBB_LIB}")
+	else()
+		message(FATAL_ERROR "Couldn't find system tbb")
+	endif()
+else()
+	set(TBB_SRC "${PROJECT_BINARY_DIR}/tbb-prefix/src/tbb")
+
+	message(STATUS "Using bundled tbb in '${TBB_SRC}'")
+
+	set(TBB_INCLUDE "${TBB_SRC}/include/")
+	set(TBB_LIB "${TBB_SRC}/build/lib_release/libtbb.a")
+	ExternalProject_Add(tbb
+		URL "https://github.com/01org/tbb/archive/2018_U5.tar.gz" # FIXME
+		URL_MD5 "ff3ae09f8c23892fbc3008c39f78288f"
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND ${CMD_MAKE} tbb_build_dir=${TBB_SRC}/build tbb_build_prefix=lib extra_inc=big_iron.inc
+		BUILD_IN_SOURCE 1
+		BUILD_BYPRODUCTS ${TBB_LIB}
+		INSTALL_COMMAND "")
+endif()
+
 install(FILES falco.yaml
 	DESTINATION "${FALCO_ETC_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,7 +412,7 @@ else()
 	set(TBB_INCLUDE "${TBB_SRC}/include/")
 	set(TBB_LIB "${TBB_SRC}/build/lib_release/libtbb.a")
 	ExternalProject_Add(tbb
-		URL "https://github.com/01org/tbb/archive/2018_U5.tar.gz" # FIXME
+		URL "http://s3.amazonaws.com/download.draios.com/dependencies/tbb-2018_U5.tar.gz"
 		URL_MD5 "ff3ae09f8c23892fbc3008c39f78288f"
 		CONFIGURE_COMMAND ""
 		BUILD_COMMAND ${CMD_MAKE} tbb_build_dir=${TBB_SRC}/build tbb_build_prefix=lib extra_inc=big_iron.inc


### PR DESCRIPTION
Falco counterpart of https://github.com/draios/sysdig/pull/1213.

As for the sysdig PR, once the PR is approved the download URL for TBB has to be changed to point under `download.draios.com`.